### PR TITLE
Get matching node for current test class / method

### DIFF
--- a/inc/baseCase.php
+++ b/inc/baseCase.php
@@ -96,9 +96,11 @@ abstract class phpcr_suite_baseCase extends PHPUnit_Framework_TestCase
          */
         $this->node = null;
         $children = $this->rootNode->getNodes("tests_*");
-        $child = current($children);
-        if (false !== $child) {
-            $this->node = $child->hasNode($this->getName()) ? $child->getNode($this->getName()) : null;
+        foreach($children as $child){
+            if($child->hasNode($this->getName())){
+                $this->node = $child->getNode($this->getName());
+                break;
+            }
         }
     }
 


### PR DESCRIPTION
During the api-tests of the mongodb transport layer I had the problem, that $this->node of the phpcr_suite_baseCase had been NULL for the most time. So I checked the section where the node get determined.

In my opinion there should be a loop through all childs to get the matching node for the test case. Maybe I'm wrong and missed something, but after the fix, some more tests getting passed without throwing exceptions or errors :-)

regards,
chirimoya
