### PR TITLE
Add UnSupportedRepositoryOperationException checks back to versioning test

### DIFF
--- a/tests/15_Versioning/CheckinCheckoutNodeTest.php
+++ b/tests/15_Versioning/CheckinCheckoutNodeTest.php
@@ -19,7 +19,11 @@ class CheckinCheckoutNodeTest extends \PHPCR\Test\BaseCase
     {
         parent::setUp();
         $this->node = $this->sharedFixture['session']->getNode('/tests_version_base/versionable');
-        $this->vm = $this->sharedFixture['session']->getWorkspace()->getVersionManager();
+        try {
+            $this->vm = $this->sharedFixture['session']->getWorkspace()->getVersionManager();
+        } catch (\PHPCR\UnSupportedRepositoryOperationException $e) {
+            $this->markTestSkipped("Versioning not supported: " . $e->getMessage());
+        }
     }
 
     public function testCheckinVersion() {

--- a/tests/15_Versioning/CreateVersionableNodeTest.php
+++ b/tests/15_Versioning/CreateVersionableNodeTest.php
@@ -19,7 +19,11 @@ class CreateVersionableNodeTest extends \PHPCR\Test\BaseCase
     {
         parent::setUp();
         $this->node = $this->sharedFixture['session']->getNode('/tests_version_base/versionable');
-        $this->vm = $this->sharedFixture['session']->getWorkspace()->getVersionManager();
+        try {
+            $this->vm = $this->sharedFixture['session']->getWorkspace()->getVersionManager();
+        } catch (\PHPCR\UnSupportedRepositoryOperationException $e) {
+            $this->markTestSkipped("Versioning not supported: " . $e->getMessage());
+        }
     }
 
     public function testAddVersionableMixin()

--- a/tests/15_Versioning/RestoreNodeTest.php
+++ b/tests/15_Versioning/RestoreNodeTest.php
@@ -18,7 +18,11 @@ class RestoreNodeTest extends \PHPCR\Test\BaseCase
     public function setUp()
     {
         parent::setUp();
-        $this->vm = $this->sharedFixture['session']->getWorkspace()->getVersionManager();
+        try {
+            $this->vm = $this->sharedFixture['session']->getWorkspace()->getVersionManager();
+        } catch (\PHPCR\UnSupportedRepositoryOperationException $e) {
+            $this->markTestSkipped("Versioning not supported: " . $e->getMessage());
+        }
     }
 
     public function testRestoreversion() {

--- a/tests/15_Versioning/VersionHistoryTest.php
+++ b/tests/15_Versioning/VersionHistoryTest.php
@@ -15,7 +15,11 @@ class VersionHistoryTest extends \PHPCR\Test\BaseCase
         parent::setupBeforeClass($fixtures);
 
         //have some versions
-        $vm = self::$staticSharedFixture['session']->getWorkspace()->getVersionManager();
+        try {
+            $vm = self::$staticSharedFixture['session']->getWorkspace()->getVersionManager();
+        } catch (\PHPCR\UnSupportedRepositoryOperationException $e) {
+            return;
+        }
         $node = self::$staticSharedFixture['session']->getNode('/tests_version_base/versioned');
         $vm->checkpoint('/tests_version_base/versioned');
         $node->setProperty('foo', 'bar');
@@ -33,7 +37,11 @@ class VersionHistoryTest extends \PHPCR\Test\BaseCase
     public function setUp()
     {
         parent::setUp();
-        $this->vm = $this->sharedFixture['session']->getWorkspace()->getVersionManager();
+        try {
+            $this->vm = $this->sharedFixture['session']->getWorkspace()->getVersionManager();
+        } catch (\PHPCR\UnSupportedRepositoryOperationException $e) {
+            $this->markTestSkipped("Versioning not supported: " . $e->getMessage());
+        }
     }
 
     //TODO: missing methods

--- a/tests/15_Versioning/VersionTest.php
+++ b/tests/15_Versioning/VersionTest.php
@@ -20,7 +20,11 @@ class VersionTest extends \PHPCR\Test\BaseCase
         parent::setupBeforeClass($fixtures);
 
         //have some versions
-        $vm = self::$staticSharedFixture['session']->getWorkspace()->getVersionManager();
+        try {
+            $vm = self::$staticSharedFixture['session']->getWorkspace()->getVersionManager();
+        } catch (\PHPCR\UnSupportedRepositoryOperationException $e) {
+            return;
+        }
 
         $node = self::$staticSharedFixture['session']->getNode('/tests_version_base/versioned');
         $vm->checkpoint('/tests_version_base/versioned');
@@ -40,7 +44,12 @@ class VersionTest extends \PHPCR\Test\BaseCase
     {
         parent::setUp();
 
-        $this->vm = $this->sharedFixture['session']->getWorkspace()->getVersionManager();
+        try {
+            $this->vm = $this->sharedFixture['session']->getWorkspace()->getVersionManager();
+        } catch (\PHPCR\UnSupportedRepositoryOperationException $e) {
+            $this->markTestSkipped("Versioning not supported: " . $e->getMessage());
+        }
+
         $this->version = $this->vm->getBaseVersion("/tests_version_base/versioned");
 
         $this->assertInstanceOf('PHPCR\Version\VersionInterface', $this->version);


### PR DESCRIPTION
Seems there was a regression with bug #6. This should fix at least parts of it.
