### PR TITLE
Whitespace added to example Sql2ScannerTest query

### DIFF
--- a/tests/06_Query/QOM/Sql2ScannerTest.php
+++ b/tests/06_Query/QOM/Sql2ScannerTest.php
@@ -17,7 +17,11 @@ class Sql2ScannerTest extends \PHPCR\Test\BaseCase
     {
         parent::setUp();
 
-        $this->sql2 = 'SELECT * FROM [nt:file] INNER JOIN [nt:folder] ON ISSAMENODE(sel1, sel2, [/home])';
+        $this->sql2 = '
+            SELECT * FROM
+                [nt:file]
+            INNER JOIN
+                [nt:folder] ON ISSAMENODE(sel1, sel2, [/home])';
         $this->tokens = array(
             'SELECT', '*', 'FROM','[nt:file]', 'INNER', 'JOIN', '[nt:folder]',
             'ON', 'ISSAMENODE', '(', 'sel1', ',', 'sel2', ',', '[/home]', ')');


### PR DESCRIPTION
This change shows that whitespace will break the Sql2Scanner, there is a pull request at
https://github.com/phpcr/phpcr-utils/pull/2 to fix the Sql2Scanner.
