### PR TITLE
Avoid assertEquals, as it can make PHP crash if there are circular references

### DIFF
--- a/tests/05_Reading/PropertyReadMethodsTest.php
+++ b/tests/05_Reading/PropertyReadMethodsTest.php
@@ -409,7 +409,7 @@ class PropertyReadMethodsTest extends \PHPCR\Test\BaseCase
         $this->assertEquals('/tests_general_base/index.txt/jcr:content/mydateprop', $properties[1]->getPath());
 
         $expected = array($this->valProperty, $this->dateProperty);
-        $this->assertSame($expected, $properties);
+        $this->assertEquals($expected, $properties, '', 0, 3);
     }
 
     /**


### PR DESCRIPTION
It appears using [assertSame can be dangerous](https://github.com/sebastianbergmann/phpunit/issues/296) with complex objects that may have circular references. Because of this, I would suggest going with a depth-controlled assertEquals instead.

This fixes a segfault with the Midgard PHPCR provider when comparing two sets of Property objects:
http://pastebin.com/at55eGP4
