### PR TITLE
Sort properties alphabetically

### DIFF
--- a/tests/08_NodeTypeDiscovery/NodeTypeTest.php
+++ b/tests/08_NodeTypeDiscovery/NodeTypeTest.php
@@ -131,7 +131,7 @@ class NodeTypeTest extends \PHPCR\Test\BaseCase
             $names[] = $prop->getName();
         }
         sort($names);
-        $this->assertEquals(array('jcr:createdBy', 'jcr:created', 'jcr:mixinTypes', 'jcr:primaryType'), $names);
+        $this->assertEquals(array('jcr:created', 'jcr:createdBy', 'jcr:mixinTypes', 'jcr:primaryType'), $names);
     }
 
     public function testIsNodeTypePrimary()


### PR DESCRIPTION
For the property definition test to succeed we need to ensure the properties are sorted in the same order as the array we use.
