### PR TITLE
Make the RemoveSessionRefreshKeepChanges fail more gracefully

### DIFF
--- a/tests/10_Writing/CombinedManipulationsTest.php
+++ b/tests/10_Writing/CombinedManipulationsTest.php
@@ -172,6 +172,7 @@ class CombinedManipulationsTest extends \PHPCR\Test\BaseCase
         $this->assertFalse($session->nodeExists($node->getPath() . '/child'));
 
         $session->refresh(true);
+        $this->assertTrue($node->hasProperty('prop'));
         $this->assertEquals('Old', $node->getPropertyValue('prop'));
         $this->assertFalse($node->hasNode('child'));
         $this->assertFalse($session->nodeExists($node->getPath() . '/child'));


### PR DESCRIPTION
In general, this test needs a bit of thought. The way I interpret `keepChanges` is that also property deletions (`$node->setProperty('prop', null);`) should be retained.

But for now, at least the test fails more gracefully. 
