### PR TITLE
Fix the test on removed properties and keepChanges

### DIFF
--- a/tests/10_Writing/CombinedManipulationsTest.php
+++ b/tests/10_Writing/CombinedManipulationsTest.php
@@ -172,8 +172,8 @@ class CombinedManipulationsTest extends \PHPCR\Test\BaseCase
         $this->assertFalse($session->nodeExists($node->getPath() . '/child'));
 
         $session->refresh(true);
-        $this->assertTrue($node->hasProperty('prop'));
-        $this->assertEquals('Old', $node->getPropertyValue('prop'));
+        $this->assertFalse($node->hasProperty('prop'));
+        $this->assertFalse($session->propertyExists($node->getPath() . '/prop'));
         $this->assertFalse($node->hasNode('child'));
         $this->assertFalse($session->nodeExists($node->getPath() . '/child'));
     }


### PR DESCRIPTION
as discussed with @dbu, this test was wrong: if you remove a property and refresh with keepChanges, the property should stay removed.
