### PR TITLE
Space seems to actually be a valid node name according to the specification

### DIFF
--- a/tests/05_Reading/NodeReadMethodsTest.php
+++ b/tests/05_Reading/NodeReadMethodsTest.php
@@ -132,7 +132,8 @@ class NodeReadMethodsTest extends \PHPCR\Test\BaseCase
      */
     public function testGetNodeRepositoryException()
     {
-        $this->rootNode->getNode('/ /'); //space is not valid in path
+        // @see http://www.day.com/specs/jcr/2.0/3_Repository_Model.html#3.2.2%20Local%20Names
+        $this->rootNode->getNode('/./');
     }
 
     public function testGetNodes()


### PR DESCRIPTION
Fix a test that seems to be testing the wrong thing.

Damien
