### PR TITLE
consistency change from phpcr/implementation to phpcr/phpcr-implementation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "phpcr/implementation": ">=0"
+        "phpcr/phpcr-implementation": ">=0"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
please let it be so, as it makes more sense to be explicit in telling which implementation is for, the other PR composer.jsons I am PR'eing for jackalope and jackrabbit suppose this change.

cc @dbu @Seldaek
