### PR TITLE
Add a node with unregistered namespace doesn't throw an exception

### DIFF
--- a/fixtures/10_Writing/add.xml
+++ b/fixtures/10_Writing/add.xml
@@ -60,6 +60,11 @@
       <sv:value>nt:folder</sv:value>
     </sv:property>
   </sv:node>
+  <sv:node sv:name="testAddNodeWithUnregisteredNamespace">
+    <sv:property sv:name="jcr:primaryType" sv:type="Name">
+      <sv:value>nt:unstructured</sv:value>
+    </sv:property>
+  </sv:node>
   <sv:node sv:name="testAddPropertyOnUnstructured">
     <sv:property sv:name="jcr:primaryType" sv:type="Name">
       <sv:value>nt:unstructured</sv:value>

--- a/tests/10_Writing/AddMethodsTest.php
+++ b/tests/10_Writing/AddMethodsTest.php
@@ -295,4 +295,19 @@ class AddMethodsTest extends \PHPCR\Test\BaseCase
         $this->assertInstanceOf('PHPCR\NodeInterface', $child);
     }
 
+    /**
+     * try to add a node with an unregistered namespace
+     * @expectedException \PHPCR\RepositoryException
+     */
+    public function testAddNodeWithUnregisteredNamespace()
+    {
+        $namespace = 'testUnregisteredNamespace';
+        $nodeName =  'child';
+
+        //add the node with an unregistered namespace, should throw a RepositoryException
+        $this->node->addNode($namespace . ':' . $nodeName, 'nt:unstructured');
+
+        //save the changes
+        $this->saveAndRenewSession();
+    }
 }


### PR DESCRIPTION
New test to cover the issue from jackalope-doctrine-dbal: https://github.com/jackalope/jackalope-doctrine-dbal/issues/8
