### PR TITLE
Get language for jqom should be SQL2 not JQOM

### DIFF
--- a/tests/06_Query/QueryObjectQOMTest.php
+++ b/tests/06_Query/QueryObjectQOMTest.php
@@ -69,7 +69,7 @@ class QueryObjectQOMTest extends QueryBaseCase
 
     public function testGetLanguage()
     {
-        $this->assertEquals(\PHPCR\Query\QueryInterface::JCR_JQOM, $this->query->getLanguage());
+        $this->assertEquals(\PHPCR\Query\QueryInterface::JCR_SQL2, $this->query->getLanguage());
     }
 
     /**


### PR DESCRIPTION
```
From the specs:
```

String Query.getLanguage()

returns the language in which the query is specified. 

If the Query was created with an explicitly supplied language string parameter using QueryManager.createQuery then this method returns that string.

If the Query is actually a QueryObjectModel created with QueryObjectModelFactory.createQuery then Query.getLanguage will return the string constant Query.JCR_SQL2.
