### PR TITLE
jcr:lastModified is a Date and not a String

### DIFF
--- a/fixtures/10_Writing/copy.xml
+++ b/fixtures/10_Writing/copy.xml
@@ -37,7 +37,7 @@
           <sv:property sv:name="jcr:data" sv:type="String">
             <sv:value>aDEuIENoYXB0ZXIgMSBUaXRsZQoKCiogZm9vCiogYmFyCioqIGZvbzIKKiogZm9vMwoqIGZvbzAKCnx8IGhlYWRlciB8fCBiYXIgfHwKfCBoIHwgaiB8IAoKW0Zvb3wgaHR0cDovL2xpaXAuY2hdCgp7Y29kZX0KaGVsbG8gd29ybGQKe2NvZGV9CgojIGZvbwojIGIKCgpoMi4gU2VjdGlvbiAxLjEgVGl0bGUKCgpTdWJzZWN0aW9uIDEuMS4xIFRpdGxlCn5+fn5+fn5+fn5+fn5+fn5+fn5+fn4KClNlY3Rpb24gMS4yIFRpdGxlCi0tLS0tLS0tLS0tLS0tLS0tCgpDaGFwdGVyIDIgVGl0bGUKPT09PT09PT09PT09PT09Cg==</sv:value>
           </sv:property>
-          <sv:property sv:name="jcr:lastModified" sv:type="String">
+          <sv:property sv:name="jcr:lastModified" sv:type="Date">
             <sv:value>2009-04-27T13:01:07.472+02:00</sv:value>
           </sv:property>
           <sv:property sv:name="jcr:mimeType" sv:type="String">
@@ -88,7 +88,7 @@
         <sv:property sv:name="jcr:data" sv:type="String">
           <sv:value>aDEuIENoYXB0ZXIgMSBUaXRsZQoKCiogZm9vCiogYmFyCioqIGZvbzIKKiogZm9vMwoqIGZvbzAKCnx8IGhlYWRlciB8fCBiYXIgfHwKfCBoIHwgaiB8IAoKW0Zvb3wgaHR0cDovL2xpaXAuY2hdCgp7Y29kZX0KaGVsbG8gd29ybGQKe2NvZGV9CgojIGZvbwojIGIKCgpoMi4gU2VjdGlvbiAxLjEgVGl0bGUKCgpTdWJzZWN0aW9uIDEuMS4xIFRpdGxlCn5+fn5+fn5+fn5+fn5+fn5+fn5+fn4KClNlY3Rpb24gMS4yIFRpdGxlCi0tLS0tLS0tLS0tLS0tLS0tCgpDaGFwdGVyIDIgVGl0bGUKPT09PT09PT09PT09PT09Cg==</sv:value>
         </sv:property>
-        <sv:property sv:name="jcr:lastModified" sv:type="String">
+        <sv:property sv:name="jcr:lastModified" sv:type="Date">
           <sv:value>2009-04-27T13:01:07.472+02:00</sv:value>
         </sv:property>
         <sv:property sv:name="jcr:mimeType" sv:type="String">
@@ -113,7 +113,7 @@
         <sv:property sv:name="jcr:primaryType" sv:type="Name">
           <sv:value>nt:unstructured</sv:value>
         </sv:property>
-        <sv:property sv:name="jcr:lastModified" sv:type="String">
+        <sv:property sv:name="jcr:lastModified" sv:type="Date">
           <sv:value>2009-04-27T13:01:07.472+02:00</sv:value>
         </sv:property>
         <sv:property sv:name="jcr:mimeType" sv:type="String">
@@ -261,7 +261,7 @@
           <sv:property sv:name="jcr:data" sv:type="String">
             <sv:value>aDEuIENoYXB0ZXIgMSBUaXRsZQoKCiogZm9vCiogYmFyCioqIGZvbzIKKiogZm9vMwoqIGZvbzAKCnx8IGhlYWRlciB8fCBiYXIgfHwKfCBoIHwgaiB8IAoKW0Zvb3wgaHR0cDovL2xpaXAuY2hdCgp7Y29kZX0KaGVsbG8gd29ybGQKe2NvZGV9CgojIGZvbwojIGIKCgpoMi4gU2VjdGlvbiAxLjEgVGl0bGUKCgpTdWJzZWN0aW9uIDEuMS4xIFRpdGxlCn5+fn5+fn5+fn5+fn5+fn5+fn5+fn4KClNlY3Rpb24gMS4yIFRpdGxlCi0tLS0tLS0tLS0tLS0tLS0tCgpDaGFwdGVyIDIgVGl0bGUKPT09PT09PT09PT09PT09Cg==</sv:value>
           </sv:property>
-          <sv:property sv:name="jcr:lastModified" sv:type="String">
+          <sv:property sv:name="jcr:lastModified" sv:type="Date">
             <sv:value>2009-04-27T13:01:07.472+02:00</sv:value>
           </sv:property>
           <sv:property sv:name="jcr:mimeType" sv:type="String">

--- a/fixtures/10_Writing/move.xml
+++ b/fixtures/10_Writing/move.xml
@@ -37,7 +37,7 @@
           <sv:property sv:name="jcr:data" sv:type="String">
             <sv:value>aDEuIENoYXB0ZXIgMSBUaXRsZQoKCiogZm9vCiogYmFyCioqIGZvbzIKKiogZm9vMwoqIGZvbzAKCnx8IGhlYWRlciB8fCBiYXIgfHwKfCBoIHwgaiB8IAoKW0Zvb3wgaHR0cDovL2xpaXAuY2hdCgp7Y29kZX0KaGVsbG8gd29ybGQKe2NvZGV9CgojIGZvbwojIGIKCgpoMi4gU2VjdGlvbiAxLjEgVGl0bGUKCgpTdWJzZWN0aW9uIDEuMS4xIFRpdGxlCn5+fn5+fn5+fn5+fn5+fn5+fn5+fn4KClNlY3Rpb24gMS4yIFRpdGxlCi0tLS0tLS0tLS0tLS0tLS0tCgpDaGFwdGVyIDIgVGl0bGUKPT09PT09PT09PT09PT09Cg==</sv:value>
           </sv:property>
-          <sv:property sv:name="jcr:lastModified" sv:type="String">
+          <sv:property sv:name="jcr:lastModified" sv:type="Date">
             <sv:value>2009-04-27T13:01:07.472+02:00</sv:value>
           </sv:property>
           <sv:property sv:name="jcr:mimeType" sv:type="String">


### PR DESCRIPTION
In the fixtures, the  property jcr:lastModified needs to be of type Date and not String for doctrine-dbal backend. 

Don't forget to generate your fixtures again... It will be needed to run the moveNode tests successfully with jackalope-doctrine-dbal.
