### PR TITLE
New test for the NodeType implementation

### DIFF
--- a/tests/08_NodeTypeDiscovery/NodeTypeTest.php
+++ b/tests/08_NodeTypeDiscovery/NodeTypeTest.php
@@ -137,6 +137,7 @@ class NodeTypeTest extends \PHPCR\Test\BaseCase
     public function testIsNodeTypePrimary()
     {
         $this->assertTrue(self::$file->isNodeType('nt:file'));
+        $this->assertTrue(self::$file->isNodeType('nt:hierarchyNode'));
         $this->assertTrue(self::$file->isNodeType('nt:base'));
         $this->assertFalse(self::$file->isNodeType('nt:resource'));
     }

--- a/tests/10_Writing/CombinedManipulationsTest.php
+++ b/tests/10_Writing/CombinedManipulationsTest.php
@@ -240,7 +240,6 @@ class CombinedManipulationsTest extends \PHPCR\Test\BaseCase
         $node->remove();
         $this->assertFalse($session->nodeExists($path));
         $session->move($this->node->getPath().'/other', $path);
-
         $this->assertTrue($session->nodeExists($path));
         $parent = $this->node->getNode('parent');
         $this->assertTrue($parent->hasNode('child'));


### PR DESCRIPTION
According to https://github.com/jackalope/jackalope-doctrine-dbal/issues/21 a new test is needed to test the node and property removal because the property jcr:created isn't available yet inside jackalope-doctrine-dbal. 

the following pull request should be merged first: https://github.com/jackalope/jackalope/pull/120
