### PR TITLE
[WIP] Add two new tests for combinations of move and order nodes

### DIFF
--- a/fixtures/23_OrderableChildNodes/orderable.xml
+++ b/fixtures/23_OrderableChildNodes/orderable.xml
@@ -363,63 +363,7 @@
         </sv:node>
     </sv:node>
 
-    <sv:node sv:name="testNodeMoveAfterOrder">
-        <sv:property sv:name="jcr:primaryType" sv:type="Name">
-            <sv:value>nt:unstructured</sv:value>
-        </sv:property>
-        <sv:node sv:name="src">
-            <sv:property sv:name="jcr:primaryType" sv:type="Name">
-                <sv:value>nt:unstructured</sv:value>
-            </sv:property>
-            <sv:node sv:name="one">
-                <sv:property sv:name="jcr:primaryType" sv:type="Name">
-                  <sv:value>nt:unstructured</sv:value>
-                </sv:property>
-            </sv:node>
-            <sv:node sv:name="two">
-                <sv:property sv:name="jcr:primaryType" sv:type="Name">
-                    <sv:value>nt:unstructured</sv:value>
-                </sv:property>
-            </sv:node>
-            <sv:node sv:name="three">
-                <sv:property sv:name="jcr:primaryType" sv:type="Name">
-                    <sv:value>nt:unstructured</sv:value>
-                </sv:property>
-            </sv:node>
-            <sv:node sv:name="four">
-                <sv:property sv:name="jcr:primaryType" sv:type="Name">
-                    <sv:value>nt:unstructured</sv:value>
-                </sv:property>
-            </sv:node>
-        </sv:node>
-        <sv:node sv:name="dst">
-            <sv:property sv:name="jcr:primaryType" sv:type="Name">
-                <sv:value>nt:unstructured</sv:value>
-            </sv:property>
-            <sv:node sv:name="one">
-                <sv:property sv:name="jcr:primaryType" sv:type="Name">
-                  <sv:value>nt:unstructured</sv:value>
-                </sv:property>
-            </sv:node>
-            <sv:node sv:name="two">
-                <sv:property sv:name="jcr:primaryType" sv:type="Name">
-                    <sv:value>nt:unstructured</sv:value>
-                </sv:property>
-            </sv:node>
-            <sv:node sv:name="three">
-                <sv:property sv:name="jcr:primaryType" sv:type="Name">
-                    <sv:value>nt:unstructured</sv:value>
-                </sv:property>
-            </sv:node>
-            <sv:node sv:name="four">
-                <sv:property sv:name="jcr:primaryType" sv:type="Name">
-                    <sv:value>nt:unstructured</sv:value>
-                </sv:property>
-            </sv:node>
-        </sv:node>
-    </sv:node>
-
-    <sv:node sv:name="testNodeOrderAfterMove">
+    <sv:node sv:name="testNodeOrderAfterOrderAndMove">
         <sv:property sv:name="jcr:primaryType" sv:type="Name">
             <sv:value>nt:unstructured</sv:value>
         </sv:property>

--- a/tests/23_OrderableChildNodes/OrderBeforeTest.php
+++ b/tests/23_OrderableChildNodes/OrderBeforeTest.php
@@ -387,63 +387,41 @@ class OrderBeforeTest extends \PHPCR\Test\BaseCase
     /**
      * \PHPCR\NodeInterface::orderBefore
      */
-    public function testNodeMoveAfterOrder()
+    public function testNodeOrderAfterOrderAndMove()
     {
         $session = $this->sharedFixture['session'];
         $this->assertInstanceOf('\PHPCR\NodeInterface', $this->node);
 
-        $src = '/tests_write_manipulation_move/testNodeMoveAfterOrder/src';
-        $dst = '/tests_write_manipulation_move/testNodeMoveAfterOrder/dst';
+        $src = '/tests_write_manipulation_move/testNodeOrderAfterOrderAndMove/src';
+        $dst = '/tests_write_manipulation_move/testNodeOrderAfterOrderAndMove/dst';
 
-        $srcNode = $session->getNode($src);
-        $dstNode = $session->getNode($dst);
+        $srcParentNode = $session->getNode($src);
+        $dstParentNode = $session->getNode($dst);
 
-        $srcNode->orderBefore('three', 'two');
-        $dstNode->orderBefore('three', 'two');
+        $srcParentNode->orderBefore('three', 'two');
+        $dstParentNode->orderBefore('three', 'two');
         
         $session->move($src . '/three', $dst . '/moved-three');
         $dstNode = $session->getNode($dst . '/moved-three');        
         $this->assertInstanceOf('PHPCR\NodeInterface', $dstNode);
+        
+        $dstParentNode = $session->getNode($dst);        
+        $this->assertChildOrder(array('one', 'three', 'two', 'four', 'moved-three'), $dstParentNode);
+
+        $srcParentNode = $session->getNode($src);        
+        $this->assertChildOrder(array('one', 'two', 'four'), $srcParentNode);
 
         $session->save();
 
         $session = $this->renewSession();
-        $dstNode = $session->getNode($dst . '/moved-three');
-        $this->assertInstanceOf('PHPCR\NodeInterface', $dstNode);
-    }
-
-    /**
-     * \PHPCR\NodeInterface::orderBefore
-     */
-    public function testNodeOrderAfterMove()
-    {
-        $session = $this->sharedFixture['session'];
-        $this->assertInstanceOf('\PHPCR\NodeInterface', $this->node);
-
-        $src = '/tests_write_manipulation_move/testNodeMoveAfterOrder/src';
-        $dst = '/tests_write_manipulation_move/testNodeMoveAfterOrder/dst';
-
-        $srcNode = $session->getNode($src);
-        $dstNode = $session->getNode($dst);
-
-        $srcNode->orderBefore('three', 'two');
-        $dstNode->orderBefore('three', 'two');
-        
-        $session->move($src . '/three', $dst . '/moved-three');
-        
-        $dstNode = $session->getNode($dst . '/moved-three');        
-        $this->assertInstanceOf('PHPCR\NodeInterface', $dstNode);
-
-        $this->assertChildOrder(array('one', 'three', 'two', 'four', 'moved-three'), $dstNode);
-
-        $session->save();
-        $this->assertChildOrder(array('one', 'three', 'two', 'four', 'moved-three'), $dstNode);
-
-        $session = $this->renewSession();
 
         $dstNode = $session->getNode($dst . '/moved-three');
-        $this->assertChildOrder(array('one', 'three', 'two', 'four', 'moved-three'), $dstNode);
+        $this->assertInstanceOf('PHPCR\NodeInterface', $dstNode);
+
+        $dstParentNode = $session->getNode($dst);        
+        $this->assertChildOrder(array('one', 'three', 'two', 'four', 'moved-three'), $dstParentNode);
+
+        $srcParentNode = $session->getNode($src);        
+        $this->assertChildOrder(array('one', 'two', 'four'), $srcParentNode);
     }
 }
-
-


### PR DESCRIPTION
Test for moving a node after it has been explicitly ordered.

Test for the final sort order of a node after it has been ordered, and then moved to a new location.

Marked WIP as both these tests currently fail even for jackrabbit, so be good to get them double checked. However I think it might be a similar issue to  https://github.com/jackalope/jackalope/issues/99.
