### PR TITLE
Test for moving nodes with similar named siblings, when already in memory

### DIFF
--- a/fixtures/10_Writing/move.xml
+++ b/fixtures/10_Writing/move.xml
@@ -172,6 +172,68 @@
         </sv:property>
     </sv:node>
   </sv:node>
+
+  <sv:node sv:name="testSessionMoveSimilarSiblingsInMemory">
+    <sv:property sv:name="jcr:primaryType" sv:type="Name">
+        <sv:value>nt:unstructured</sv:value>
+    </sv:property>
+    <sv:node sv:name="srcNode">
+        <sv:property sv:name="jcr:primaryType" sv:type="Name">
+            <sv:value>nt:folder</sv:value>
+        </sv:property>
+        <sv:property sv:name="jcr:created" sv:type="Date">
+            <sv:value>2012-05-11T09:51:12.433+02:00</sv:value>
+        </sv:property>
+        <sv:property sv:name="jcr:createdBy" sv:type="String">
+            <sv:value>admin</sv:value>
+        </sv:property>
+        <sv:node sv:name="another">
+            <sv:property sv:name="jcr:primaryType" sv:type="Name">
+                <sv:value>nt:folder</sv:value>
+            </sv:property>
+            <sv:property sv:name="jcr:created" sv:type="Date">
+                <sv:value>2012-05-11T09:58:12.463+02:00</sv:value>
+            </sv:property>
+            <sv:property sv:name="jcr:createdBy" sv:type="String">
+                <sv:value>admin</sv:value>
+            </sv:property>
+        </sv:node>
+    </sv:node>
+    <sv:node sv:name="srcNodeSibling">
+        <sv:property sv:name="jcr:primaryType" sv:type="Name">
+            <sv:value>nt:folder</sv:value>
+        </sv:property>
+        <sv:property sv:name="jcr:created" sv:type="Date">
+            <sv:value>2012-05-11T09:55:22.322+02:00</sv:value>
+        </sv:property>
+        <sv:property sv:name="jcr:createdBy" sv:type="String">
+            <sv:value>admin</sv:value>
+        </sv:property>
+        <sv:node sv:name="another">
+            <sv:property sv:name="jcr:primaryType" sv:type="Name">
+                <sv:value>nt:folder</sv:value>
+            </sv:property>
+            <sv:property sv:name="jcr:created" sv:type="Date">
+                <sv:value>2012-05-11T09:59:34.957+02:00</sv:value>
+            </sv:property>
+            <sv:property sv:name="jcr:createdBy" sv:type="String">
+                <sv:value>admin</sv:value>
+            </sv:property>
+        </sv:node>
+    </sv:node>
+    <sv:node sv:name="dstNode">
+        <sv:property sv:name="jcr:primaryType" sv:type="Name">
+            <sv:value>nt:folder</sv:value>
+        </sv:property>
+        <sv:property sv:name="jcr:created" sv:type="Date">
+            <sv:value>2012-05-11T09:52:22.213+02:00</sv:value>
+        </sv:property>
+        <sv:property sv:name="jcr:createdBy" sv:type="String">
+            <sv:value>admin</sv:value>
+        </sv:property>
+    </sv:node>
+  </sv:node>
+
   <sv:node sv:name="testSessionMoveReferenceable">
     <sv:property sv:name="jcr:primaryType" sv:type="Name">
       <sv:value>nt:unstructured</sv:value>

--- a/tests/10_Writing/MoveMethodsTest.php
+++ b/tests/10_Writing/MoveMethodsTest.php
@@ -98,6 +98,59 @@ class MoveMethodsTest extends \PHPCR\Test\BaseCase
         $this->assertFalse($session->nodeExists($probDst), 'Sibling nodes should\'nt be moved');
     }
 
+    /**
+     * Try to move nodes that are already held in memory:
+     *
+     * src:     /my/path
+     * dst:     /my/new/path
+     *
+     * where the following node exists in the tree, and is already in memory:
+     * prob:    /my/pathSomething
+     *
+     * the moveNodes method should'nt consider the prob node
+     */
+    public function testSessionMoveSimilarSiblingsInMemory()
+    {
+        $session = $this->sharedFixture['session'];
+
+        $src = '/tests_write_manipulation_move/testSessionMoveSimilarSiblingsInMemory/srcNode';
+        $dst = '/tests_write_manipulation_move/testSessionMoveSimilarSiblingsInMemory/dstNode/srcNode';
+
+        $probSrc = '/tests_write_manipulation_move/testSessionMoveSimilarSiblingsInMemory/srcNodeSibling';
+        $probDst = '/tests_write_manipulation_move/testSessionMoveSimilarSiblingsInMemory/dstNode/srcNodeSibling';
+
+        $session->getNode($src);
+        $session->getNode($probSrc);
+
+        $session->move($src, $dst);
+
+        // Session
+        $this->assertTrue($session->nodeExists($dst), 'Destination node not found [S]');
+        $this->assertFalse($session->nodeExists($src), 'Source node still exists [S]');
+        $this->assertTrue($session->nodeExists($dst . '/another'), 'Destination child node not found [S]');
+        $this->assertFalse($session->nodeExists($src . '/another'), 'Source child node still exists [S]');
+        $this->assertTrue($session->nodeExists($probSrc), 'Sibling nodes should\'nt be moved');
+        $this->assertFalse($session->nodeExists($probDst), 'Sibling nodes should\'nt be moved');
+
+        $session->save();
+        $this->assertTrue($session->nodeExists($dst), 'Destination node not found [B]');
+        $this->assertFalse($session->nodeExists($src), 'Source node still exists [B]');
+        $this->assertTrue($session->nodeExists($dst . '/another'), 'Destination child node not found [B]');
+        $this->assertFalse($session->nodeExists($src . '/another'), 'Source child node still exists [B]');
+        $this->assertTrue($session->nodeExists($probSrc), 'Sibling nodes should\'nt be moved');
+        $this->assertFalse($session->nodeExists($probDst), 'Sibling nodes should\'nt be moved');
+
+        // Backend
+        $session = $this->renewSession();
+        $this->assertTrue($session->nodeExists($dst), 'Destination node not found [B]');
+        $this->assertFalse($session->nodeExists($src), 'Source node still exists [B]');
+        $this->assertTrue($session->nodeExists($dst . '/another'), 'Destination child node not found [B]');
+        $this->assertFalse($session->nodeExists($src. '/another'), 'Source child node still exists [B]');
+        $this->assertTrue($session->nodeExists($probSrc), 'Sibling nodes should\'nt be moved');
+        $this->assertFalse($session->nodeExists($probDst), 'Sibling nodes should\'nt be moved');
+    }
+
+
     public function testSessionMoveWhitespace()
     {
         $session = $this->sharedFixture['session'];


### PR DESCRIPTION
Messing with fetchDepth revealed that some of the tests fail when nodes are already in memory.

This test just duplicates the current `testSessionMoveSimilarSiblings` but specifically pulls the nodes in to memory first - so demonstrating the bug.
