### PR TITLE
add a test for the NodeHelper purge functionality

### DIFF
--- a/tests/PhpcrUtils/PurgeTest.php
+++ b/tests/PhpcrUtils/PurgeTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace PHPCR\Tests\PhpcrUtils;
+
+require_once(__DIR__ . '/../../inc/BaseCase.php');
+
+use PHPCR\PropertyType;
+use PHPCR\Util\NodeHelper;
+
+use PHPCR\Test\BaseCase;
+
+class PurgeTest extends BaseCase
+{
+    public function setUp()
+    {
+        if (! class_exists('PHPCR\Util\NodeHelper')) {
+            $this->markTestSkipped('This testbed does not have phpcr-utils available');
+        }
+        parent::setUp();
+    }
+    public function testPurge()
+    {
+        /** @var $session \PHPCR\SessionInterface */
+        $session = $this->sharedFixture['session'];
+        $emptycount = count($session->getRootNode()->getNodes()) - 1; // already has one node from fixtures
+
+        $a = $session->getRootNode()->addNode('a', 'nt:unstructured');
+        $a->addMixin('mix:referenceable');
+        $b = $session->getRootNode()->addNode('b', 'nt:unstructured');
+        $b->addMixin('mix:referenceable');
+        $session->save();
+
+        $a->setProperty('ref', $b, PropertyType::REFERENCE);
+        $b->setProperty('ref', $a, PropertyType::REFERENCE);
+        $session->save();
+
+        NodeHelper::purgeWorkspace($session);
+        $session->save();
+
+        // if there where system nodes, they should still be here
+        $this->assertCount($emptycount, $session->getRootNode()->getNodes());
+    }
+}


### PR DESCRIPTION
i am not sure if it is a good idea to add such tests here. they somehow belong into phpcr-utils, but there we currently have no full setup with an implementation. and it makes sense to test the utils with all implementations as they use functionality of phpcr and could reveal potential implementation bugs.

i autoskip the test if phpcr utils is not available.
