### PR TITLE
Fixed purgeTest

### DIFF
--- a/tests/PhpcrUtils/PurgeTest.php
+++ b/tests/PhpcrUtils/PurgeTest.php
@@ -34,7 +34,7 @@ class PurgeTest extends BaseCase
         $b->setProperty('ref', $a, PropertyType::REFERENCE);
         $session->save();
 
-        NodeHelper::purgeWorkspace($session);
+        NodeHelper::deleteAllNodes($session);
         $session->save();
 
         // if there where system nodes, they should still be here


### PR DESCRIPTION
Changed it to the correct method name.
Didn't find any clues that purgeWorkspace would be the correct one instead of deleteAllNodes.
