### PR TITLE
[WIP] child version cascade tests (fails)

### DIFF
--- a/fixtures/15_Versioning/base.xml
+++ b/fixtures/15_Versioning/base.xml
@@ -18,7 +18,7 @@
     </sv:node>
     <sv:node sv:name="versioned">
       <sv:property sv:name="jcr:primaryType" sv:type="Name">
-        <sv:value>nt:unstructured</sv:value>
+        <sv:value>phpcr:versionCascade</sv:value>
       </sv:property>
       <sv:property sv:name="jcr:mixinTypes" sv:type="Name">
         <sv:value>mix:versionable</sv:value>
@@ -26,6 +26,17 @@
       <sv:property sv:name="foo" sv:type="String">
           <sv:value>something</sv:value>
       </sv:property>
+      <sv:node sv:name="version_child">
+        <sv:property sv:name="jcr:primaryType" sv:type="Name">
+          <sv:value>phpcr:versionCascade</sv:value>
+        </sv:property>
+        <sv:property sv:name="jcr:mixinTypes" sv:type="Name">
+          <sv:value>mix:versionable</sv:value>
+        </sv:property>
+        <sv:property sv:name="foo_c" sv:type="String">
+          <sv:value>something_c</sv:value>
+        </sv:property>
+      </sv:node>
     </sv:node>
     <sv:node sv:name="simpleVersioned">
         <sv:property sv:name="jcr:primaryType" sv:type="Name">

--- a/inc/BaseCase.php
+++ b/inc/BaseCase.php
@@ -91,7 +91,8 @@ abstract class BaseCase extends \PHPUnit_Framework_TestCase
             if (! $ntm->hasNodeType('phpcr:versionCascade')) {
                 $cnd = <<<END_CND
 [phpcr:versionCascade] > nt:unstructured
-    + * multiple copy
+    - copy
+    + * copy
 END_CND;
                 $ntm->registerNodeTypesCnd($cnd, false);
             }

--- a/inc/BaseCase.php
+++ b/inc/BaseCase.php
@@ -87,6 +87,15 @@ abstract class BaseCase extends \PHPUnit_Framework_TestCase
 
         self::$staticSharedFixture['ie'] = self::$loader->getFixtureLoader();
         if ($fixtures) {
+            $ntm = self::$loader->getSession()->getWorkspace()->getNodeTypeManager();
+            if (! $ntm->hasNodeType('phpcr:versionCascade')) {
+                $cnd = <<<END_CND
+[phpcr:versionCascade] > nt:unstructured
+    + * multiple copy
+END_CND;
+                $ntm->registerNodeTypesCnd($cnd, false);
+            }
+
             self::$staticSharedFixture['ie']->import($fixtures);
         }
 


### PR DESCRIPTION
Tests to demonstrate how I believe version cascade should work. 

For now, I've added a child node to the 'versioned' node in the fixtures and added extra test cases to 15_Versioning/VersionTest.php. However, if it's better I'll be happy to move these tests to a separate test class (and with separate fixtures if needed).

Also, does the CND type look correct?

```
[phpcr:versionCascade] > nt:unstructured
    + * multiple copy
```
