### PR TITLE
[FAILING] test to illustrate clone behaviour of node with versionable child

### DIFF
--- a/fixtures/10_Writing/clone.xml
+++ b/fixtures/10_Writing/clone.xml
@@ -244,7 +244,6 @@
           <sv:value>nt:unstructured</sv:value>
         </sv:property>
         <sv:property sv:name="jcr:mixinTypes" sv:type="Name">
-          <sv:value>mix:referenceable</sv:value>
           <sv:value>mix:versionable</sv:value>
         </sv:property>
         <sv:property sv:name="jcr:uuid" sv:type="String">

--- a/fixtures/10_Writing/clone.xml
+++ b/fixtures/10_Writing/clone.xml
@@ -222,4 +222,38 @@
       </sv:property>
     </sv:node>
   </sv:node>
+  <sv:node sv:name="testWorkspaceCloneVersionable">
+    <sv:property sv:name="jcr:primaryType" sv:type="Name">
+      <sv:value>nt:unstructured</sv:value>
+    </sv:property>
+    <sv:node sv:name="referenceable">
+      <sv:property sv:name="jcr:primaryType" sv:type="Name">
+        <sv:value>nt:unstructured</sv:value>
+      </sv:property>
+      <sv:property sv:name="jcr:mixinTypes" sv:type="Name">
+        <sv:value>mix:referenceable</sv:value>
+      </sv:property>
+      <sv:property sv:name="jcr:uuid" sv:type="String">
+        <sv:value>abad6d55-9e8b-4736-8444-8c4809a88550</sv:value>
+      </sv:property>
+      <sv:property sv:name="foo" sv:type="Name">
+        <sv:value>bar</sv:value>
+      </sv:property>
+      <sv:node sv:name="cloneChild">
+        <sv:property sv:name="jcr:primaryType" sv:type="Name">
+          <sv:value>nt:unstructured</sv:value>
+        </sv:property>
+        <sv:property sv:name="jcr:mixinTypes" sv:type="Name">
+          <sv:value>mix:referenceable</sv:value>
+          <sv:value>mix:versionable</sv:value>
+        </sv:property>
+        <sv:property sv:name="jcr:uuid" sv:type="String">
+          <sv:value>46253fb2-940d-aa7f-bcad-39157cc781de</sv:value>
+        </sv:property>
+        <sv:property sv:name="fooChild" sv:type="Name">
+          <sv:value>barChild</sv:value>
+        </sv:property>
+      </sv:node>
+    </sv:node>
+  </sv:node>
 </sv:node>

--- a/tests/10_Writing/CloneMethodsTest.php
+++ b/tests/10_Writing/CloneMethodsTest.php
@@ -547,7 +547,7 @@ class CloneMethodsTest extends BaseCase
         $sourceSession = $this->srcWs->getSession();
 
         self::$destWs->cloneFrom($this->srcWsName, $srcNode, $dstNode, false);
-        $destSession->getObjectManager()->refresh(false);
+        $this->renewDestinationSession();
 
         $clonedNode = $destSession->getNode($dstNode);
         $this->checkNodeProperty($clonedNode, 'jcr:uuid', 'abad6d55-9e8b-4736-8444-8c4809a88550');

--- a/tests/10_Writing/CloneMethodsTest.php
+++ b/tests/10_Writing/CloneMethodsTest.php
@@ -38,6 +38,7 @@ class CloneMethodsTest extends BaseCase
         $node->addNode('testWorkspaceClone');
         $node->addNode('testWorkspaceCorrespondingNode');
         $node->addNode('testWorkspaceUpdateNode');
+        $node->addNode('testWorkspaceCloneVersionable');
         $destSession->save();
     }
 
@@ -530,6 +531,29 @@ class CloneMethodsTest extends BaseCase
         $this->assertCount(4, $clonedNode->getProperties());
         $this->checkNodeProperty($clonedNode, 'jcr:uuid', '1d392bcb-3e49-4f0e-b0af-7c30ab838122');
         $this->checkNodeProperty($clonedNode, 'foo', 'bar_6');
+    }
+
+    /**
+     * Test cloning a referenceable node and its versionable child.
+     * The child should not be cloned, because it is versionable.
+     */
+    public function testCloneWithVersionableChild()
+    {
+        $srcNode = '/tests_write_manipulation_clone/testWorkspaceCloneVersionable/referenceable';
+        $dstNode = $srcNode;
+        $destSession = self::$destWs->getSession();
+
+        self::$destWs->cloneFrom($this->srcWsName, $srcNode, $dstNode, false);
+
+        $destSession->getObjectManager()->refresh(false);
+
+        $clonedNode = $destSession->getNode($dstNode);
+        $this->assertCount(4, $clonedNode->getProperties());
+        $this->checkNodeProperty($clonedNode, 'jcr:uuid', 'abad6d55-9e8b-4736-8444-8c4809a88550');
+        $this->checkNodeProperty($clonedNode, 'foo', 'bar');
+
+        // The child node should not have been cloned
+        $this->assertFalse($clonedNode->hasNode('cloneChild'));
     }
 
     private function renewDestinationSession()


### PR DESCRIPTION
This might not be good to merge, but illustrates the expected behaviour of cloning a node that has a versionable child. See the discussion here:

[Re: Preview workflow based on workspace clone/node update](http://www.mail-archive.com/users@jackrabbit.apache.org/msg19369.html)

The test fails using Jackrabbit 2.6; I was expecting the child of the cloned node to be skipped, but it was cloned into the destination workspace along with its parent.
