### PR TITLE
Added 2 tests, LEFT OUTER JOIN and RIGHT OUTER JOIN

### DIFF
--- a/tests/06_Query/QuerySql2OperationsTest.php
+++ b/tests/06_Query/QuerySql2OperationsTest.php
@@ -131,7 +131,7 @@ class QuerySql2OperationsTest extends QueryBaseCase
         $this->assertInstanceOf('\PHPCR\Query\QueryResultInterface', $result);
         $vals = array();
         foreach ($result->getRows() as $row) {
-            $vals[$row->getValue('file.jcr:name')] = $row->getValue('target.longNumberToCompare');
+            $vals[basename($row->getPath('file'))] = $row->getValue('target.longNumberToCompare');
         }
 
         // We get 9 results (idExample comes back multiple times because of the join)
@@ -162,7 +162,7 @@ class QuerySql2OperationsTest extends QueryBaseCase
         $this->assertInstanceOf('\PHPCR\Query\QueryResultInterface', $result);
         $vals = array();
         foreach ($result->getRows() as $row) {
-            $vals[$row->getValue('file.jcr:name')] = $row->getValue('target.stringToCompare');
+            $vals[basename($row->getPath('file'))] = $row->getValue('target.stringToCompare');
         }
 
         // We get 9 results (idExample comes back multiple times because of the join)


### PR DESCRIPTION
Added tests for LEFT OUTER and RIGHT OUTER joins. 

Implemented them while busy for Jackalope Doctrine DBAL. 
Haven't been able to test this with Jackalope Jackrabbit or any other. But I think the tests itself are correct.
