### PR TITLE
refactored date comparisons to not care about timezone

### DIFF
--- a/inc/BaseCase.php
+++ b/inc/BaseCase.php
@@ -3,6 +3,7 @@ namespace PHPCR\Test;
 
 use PHPCR\SessionInterface;
 use PHPCR\NodeInterface;
+use \DateTime;
 
 // PHPUnit 3.4 compat
 if (method_exists('PHPUnit_Util_Filter', 'addDirectoryToFilter')) {
@@ -117,7 +118,7 @@ abstract class BaseCase extends \PHPUnit_Framework_TestCase
         $case = $parts[$case_n];
         $chapter = '';
 
-        for($i = 2; $i < $case_n; $i++) {
+        for ($i = 2; $i < $case_n; $i++) {
             $chapter .= $parts[$i] . '\\';
         }
 
@@ -240,5 +241,15 @@ abstract class BaseCase extends \PHPUnit_Framework_TestCase
     {
         $this->assertTrue($node->hasProperty($property));
         $this->assertEquals($value, $node->getPropertyValue($property));
+    }
+
+    protected function assertEqualDateString($date1, $date2)
+    {
+        $this->assertEquals(strtotime($date1), strtotime($date2));
+    }
+
+    protected function assertEqualDateTime(DateTime $date1, DateTime $date2)
+    {
+        $this->assertEquals($date1->getTimestamp(), $date2->getTimestamp());
     }
 }

--- a/tests/05_Reading/PropertyReadMethodsTest.php
+++ b/tests/05_Reading/PropertyReadMethodsTest.php
@@ -145,11 +145,11 @@ class PropertyReadMethodsTest extends \PHPCR\Test\BaseCase
      */
     public function testGetString()
     {
-        $expectedStr = '2011-04-21T14:34:20'; //date precision might not be down to milliseconds
+        $expectedStr = '2011-04-21T14:34:20+01:00'; //date precision might not be down to milliseconds
         $str = $this->dateProperty->getString();
         $this->assertInternalType('string', $str);
-        $this->assertStringStartsWith($expectedStr, $str);
 
+        $this->assertEqualDateString($expectedStr, $str);
         $str = $this->valProperty->getString();
         $this->assertInternalType('string', $str);
         $this->assertEquals('bar', $str);
@@ -298,11 +298,13 @@ class PropertyReadMethodsTest extends \PHPCR\Test\BaseCase
             $this->assertInstanceOf('DateTime', $v);
         }
         //check correct values and sort order
-        $expected = array(
+        $expectedArray = array(
                 new \DateTime('2011-04-22T14:34:20+01:00'),
                 new \DateTime('2011-10-23T14:34:20+01:00'),
                 new \DateTime('2010-10-23T14:34:20+01:00'));
-        $this->assertEquals($expected, $arr);
+        foreach ($expectedArray as $key => $expected) {
+            $this->assertEqualDateTime($expected, $arr[$key]);
+        }
     }
     /**
      * arbitrary string can not be converted to date

--- a/tests/07_Export/ExportRepositoryContentTest.php
+++ b/tests/07_Export/ExportRepositoryContentTest.php
@@ -54,6 +54,11 @@ class ExportRepositoryContentTest extends \PHPCR\Test\BaseCase
         return "/$ret";
     }
 
+    private function isDate($date)
+    {
+        return preg_match('/^\d{4}-\d{2}-\d{2}/', $date);
+    }
+
     /**
      * compare two system view documents.
      *
@@ -81,7 +86,11 @@ class ExportRepositoryContentTest extends \PHPCR\Test\BaseCase
                     $o = $output->childNodes->item($index);
                     $this->assertInstanceOf('DOMElement', $o, "No child element at $index in ".$this->buildPath($child));
                     $this->assertEquals('sv:value', $o->tagName, 'Unexpected tag name at '.$this->buildPath($expected)."sv:value[$index]");
-                    $this->assertEquals($child->textContent, $o->textContent, 'Not the same text at '.$this->buildPath($output)."sv:value[$index]");
+                    if ($this->isDate($child->textContent) && $this->isDate($o->textContent)) {
+                        $this->assertEqualDateString($child->textContent, $o->textContent, 'Not the same date at '.$this->buildPath($output)."sv:value[$index]");
+                    } else {
+                        $this->assertEquals($child->textContent, $o->textContent, 'Not the same text at '.$this->buildPath($output)."sv:value[$index]");
+                    }
                 }
             }
         } elseif ($expected->tagName == 'sv:node') {
@@ -130,7 +139,11 @@ class ExportRepositoryContentTest extends \PHPCR\Test\BaseCase
                 } else {
                     $oattr = $output->attributes->getNamedItem($attr->name);
                     $this->assertNotNull($oattr, 'missing attribute '.$attr->name.' at '.$this->buildPath($expected));
-                    $this->assertEquals($attr->value, $oattr->value, 'wrong attribute value at '.$this->buildPath($expected).'/'.$attr->name);
+                    if ($this->isDate($attr->value) && $this->isDate($oattr->value)) {
+                        $this->assertEqualDateString($attr->value, $oattr->value, 'wrong attribute value at '.$this->buildPath($expected).'/'.$attr->name);
+                    } else {
+                        $this->assertEquals($attr->value, $oattr->value, 'wrong attribute value at '.$this->buildPath($expected).'/'.$attr->name);
+                    }
                 }
             }
 


### PR DESCRIPTION
we should also add a new test which checks if timezones are restored to the originally stored timezone. not sure however where to put such a test.
