### PR TITLE
test with a couple of non-ascii characters

### DIFF
--- a/fixtures/05_Reading/encoding.xml
+++ b/fixtures/05_Reading/encoding.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sv:node
+        xmlns:mix="http://www.jcp.org/jcr/mix/1.0"
+        xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+        xmlns:jcr="http://www.jcp.org/jcr/1.0"
+        xmlns:sv="http://www.jcp.org/jcr/sv/1.0"
+
+        sv:name="tests_read_encoding">
+    <sv:property sv:name="jcr:primaryType" sv:type="Name">
+        <sv:value>nt:unstructured</sv:value>
+    </sv:property>
+    <sv:node sv:name="testEncoding">
+        <sv:property sv:name="jcr:primaryType" sv:type="Name">
+            <sv:value>nt:unstructured</sv:value>
+        </sv:property>
+        <sv:node sv:name="node-ä-x">
+            <sv:property sv:name="jcr:primaryType" sv:type="Name">
+                <sv:value>nt:unstructured</sv:value>
+            </sv:property>
+        </sv:node>
+        <sv:node sv:name="node-è-x">
+            <sv:property sv:name="jcr:primaryType" sv:type="Name">
+                <sv:value>nt:unstructured</sv:value>
+            </sv:property>
+        </sv:node>
+        <sv:node sv:name="node-ï-x">
+            <sv:property sv:name="jcr:primaryType" sv:type="Name">
+                <sv:value>nt:unstructured</sv:value>
+            </sv:property>
+        </sv:node>
+        <sv:node sv:name="node-%-x">
+            <sv:property sv:name="jcr:primaryType" sv:type="Name">
+                <sv:value>nt:unstructured</sv:value>
+            </sv:property>
+        </sv:node>
+        <sv:node sv:name="node-%2F-x">
+            <sv:property sv:name="jcr:primaryType" sv:type="Name">
+                <sv:value>nt:unstructured</sv:value>
+            </sv:property>
+        </sv:node>
+        <sv:node sv:name="node- -x">
+            <sv:property sv:name="jcr:primaryType" sv:type="Name">
+                <sv:value>nt:unstructured</sv:value>
+            </sv:property>
+        </sv:node>
+        <sv:node sv:name="node-ç-x">
+            <sv:property sv:name="jcr:primaryType" sv:type="Name">
+                <sv:value>nt:unstructured</sv:value>
+            </sv:property>
+        </sv:node>
+        <sv:node sv:name="node-&amp;-x">
+            <sv:property sv:name="jcr:primaryType" sv:type="Name">
+                <sv:value>nt:unstructured</sv:value>
+            </sv:property>
+        </sv:node>
+    </sv:node>
+</sv:node>

--- a/fixtures/10_Writing/encoding.xml
+++ b/fixtures/10_Writing/encoding.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sv:node
+        xmlns:mix="http://www.jcp.org/jcr/mix/1.0"
+        xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+        xmlns:jcr="http://www.jcp.org/jcr/1.0"
+        xmlns:sv="http://www.jcp.org/jcr/sv/1.0"
+
+        sv:name="tests_write_encoding">
+    <sv:property sv:name="jcr:primaryType" sv:type="Name">
+        <sv:value>nt:unstructured</sv:value>
+    </sv:property>
+    <sv:node sv:name="testEncoding">
+        <sv:property sv:name="jcr:primaryType" sv:type="Name">
+            <sv:value>nt:unstructured</sv:value>
+        </sv:property>
+    </sv:node>
+</sv:node>

--- a/tests/05_Reading/EncodingTest.php
+++ b/tests/05_Reading/EncodingTest.php
@@ -1,0 +1,49 @@
+<?php
+namespace PHPCR\Tests\Reading;
+
+require_once(__DIR__ . '/../../inc/BaseCase.php');
+
+/**
+ * Test javax.jcr.Node read methods (read) §5.6
+ * With special characters.
+ */
+class EncodingTest extends \PHPCR\Test\BaseCase
+{
+
+    static public function setupBeforeClass($fixtures = '05_Reading/encoding')
+    {
+        parent::setupBeforeClass($fixtures);
+    }
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        // because of the data provider the signature will not match
+        $this->node = $this->rootNode->getNode('tests_read_encoding')->getNode('testEncoding');
+    }
+
+    /**
+     * @dataProvider getNodeNames
+     */
+    public function testEncoding($name)
+    {
+        $this->assertTrue($this->node->hasNode($name));
+        $node = $this->node->getNode($name);
+        $this->assertInstanceOf('PHPCR\NodeInterface', $node);
+    }
+
+    public static function getNodeNames()
+    {
+        return array(
+            array("node-ä-x"),
+            array("node-è-x"),
+            array("node-ï-x"),
+            array("node-%-x"),
+            array("node-%2F-x"),
+            array("node- -x"),
+            array("node-ç-x"),
+            array("node-&-x"),
+        );
+    }
+}

--- a/tests/10_Writing/EncodingTest.php
+++ b/tests/10_Writing/EncodingTest.php
@@ -1,0 +1,53 @@
+<?php
+namespace PHPCR\Tests\Writing;
+
+require_once(__DIR__ . '/../../inc/BaseCase.php');
+
+/**
+ * Test javax.jcr.Node read methods (read) §5.6
+ * With special characters.
+ */
+class EncodingTest extends \PHPCR\Test\BaseCase
+{
+
+    static public function setupBeforeClass($fixtures = '10_Writing/encoding')
+    {
+        parent::setupBeforeClass($fixtures);
+    }
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        // because of the data provider the signature will not match
+        $this->node = $this->rootNode->getNode('tests_write_encoding')->getNode('testEncoding');
+    }
+
+    /**
+     * @dataProvider getNodeNames
+     */
+    public function testEncoding($name)
+    {
+        $node = $this->node->addNode($name);
+        $this->assertInstanceOf('PHPCR\NodeInterface', $node);
+
+        $session = $this->saveAndRenewSession();
+        $node = $session->getNode('/tests_write_encoding/testEncoding');
+        $this->assertTrue($node->hasNode($name));
+        $this->assertInstanceOf('PHPCR\NodeInterface', $node->getNode($name));
+    }
+
+    public static function getNodeNames()
+    {
+        return array(
+            array("node-ä-x"),
+            array("node-è-x"),
+            array("node-ï-x"),
+            array("node-%-x"),
+            array("node-%2F-x"),
+            array("node- -x"),
+            array("node-ç-x"),
+            array("node-&-x"),
+        );
+    }
+}


### PR DESCRIPTION
tests for https://github.com/jackalope/jackalope/issues/32

testing ä è ï ç % %2F space and &

can we think of any other particularly nasty things to try? `/\:[]` are all reserved and not valid in node names. but what else could we try?
