### PR TITLE
Test the operator-precedence of OR/AND/NOT

### DIFF
--- a/tests/06_Query/QOM/QomTestQueries.php
+++ b/tests/06_Query/QOM/QomTestQueries.php
@@ -136,6 +136,145 @@ class QomTestQueries {
                 array());
 
         /**
+        * 6.7.12. Constraint (operator precedence)
+        */
+        $queries['6.7.12.Constraint.Precedence.1'] = $factory->createQuery(
+            $factory->selector('nt:file'),
+            $factory->orConstraint(
+                $factory->comparison(
+                    $factory->propertyValue('prop1', 'sel1'),
+                    Constants::JCR_OPERATOR_EQUAL_TO,
+                    $factory->literal('1')
+                ),
+                $factory->andConstraint(
+                    $factory->comparison(
+                        $factory->propertyValue('prop2', 'sel1'),
+                        Constants::JCR_OPERATOR_EQUAL_TO,
+                        $factory->literal('2')
+                    ),
+                    $factory->comparison(
+                        $factory->propertyValue('prop3', 'sel1'),
+                        Constants::JCR_OPERATOR_EQUAL_TO,
+                        $factory->literal('3')
+                    )
+                )
+            ),
+            array(),
+            array()
+        );
+
+        $queries['6.7.12.Constraint.Precedence.2'] = $factory->createQuery(
+            $factory->selector('nt:file'),
+            $factory->orConstraint(
+                $factory->andConstraint(
+                    $factory->comparison(
+                        $factory->propertyValue('prop1', 'sel1'),
+                        Constants::JCR_OPERATOR_EQUAL_TO,
+                        $factory->literal('1')
+                    ),
+                    $factory->comparison(
+                        $factory->propertyValue('prop2', 'sel1'),
+                        Constants::JCR_OPERATOR_EQUAL_TO,
+                        $factory->literal('2')
+                    )
+                ),
+                $factory->comparison(
+                    $factory->propertyValue('prop3', 'sel1'),
+                    Constants::JCR_OPERATOR_EQUAL_TO,
+                    $factory->literal('3')
+                )
+            ),
+            array(),
+            array()
+        );
+
+        $queries['6.7.12.Constraint.Precedence.3'] = $factory->createQuery(
+            $factory->selector('nt:file'),
+            $factory->orConstraint(
+                $factory->notConstraint(
+                    $factory->comparison(
+                        $factory->propertyValue('prop1', 'sel1'),
+                        Constants::JCR_OPERATOR_EQUAL_TO,
+                        $factory->literal('1')
+                    )
+                ),
+                $factory->andConstraint(
+                    $factory->comparison(
+                        $factory->propertyValue('prop2', 'sel1'),
+                        Constants::JCR_OPERATOR_EQUAL_TO,
+                        $factory->literal('2')
+                    ),
+                    $factory->notConstraint(
+                        $factory->comparison(
+                            $factory->propertyValue('prop3', 'sel1'),
+                            Constants::JCR_OPERATOR_EQUAL_TO,
+                            $factory->literal('3')
+                        )
+                    )
+                )
+            ),
+            array(),
+            array()
+        );
+
+        $queries['6.7.12.Constraint.Precedence.4'] = $factory->createQuery(
+            $factory->selector('nt:file'),
+            $factory->orConstraint(
+                $factory->andConstraint(
+                    $factory->andConstraint(
+                        $factory->propertyExistence('prop1', 'sel1'),
+                        $factory->propertyExistence('prop2', 'sel1')
+                    ),
+                    $factory->propertyExistence('prop3', 'sel1')
+                ),
+                $factory->andConstraint(
+                    $factory->andConstraint(
+                        $factory->andConstraint(
+                            $factory->propertyExistence('prop4', 'sel1'),
+                            $factory->propertyExistence('prop5', 'sel1')
+                        ),
+                        $factory->propertyExistence('prop6', 'sel1')
+                    ),
+                    $factory->propertyExistence('prop7', 'sel1')
+                )
+            ),
+            array(),
+            array()
+        );
+
+        $queries['6.7.12.Constraint.Precedence.5'] = $factory->createQuery(
+            $factory->selector('nt:file'),
+            $factory->orConstraint(
+                $factory->andConstraint(
+                    $factory->notConstraint(
+                        $factory->propertyExistence('prop1', 'sel1')
+                    ),
+                    $factory->notConstraint(
+                        $factory->notConstraint(
+                            $factory->propertyExistence('prop2', 'sel1')
+                        )
+                    )
+                ),
+                $factory->andConstraint(
+                    $factory->notConstraint(
+                        $factory->comparison(
+                            $factory->propertyValue('prop3', 'sel1'),
+                            Constants::JCR_OPERATOR_EQUAL_TO,
+                            $factory->literal('hello')
+                        )
+                    ),
+                    $factory->comparison(
+                        $factory->propertyValue('prop4', 'sel1'),
+                        Constants::JCR_OPERATOR_NOT_EQUAL_TO,
+                        $factory->literal('hello')
+                    )
+                )
+            ),
+            array(),
+            array()
+        );
+
+        /**
         * 6.7.13. AndConstraint
         */
 

--- a/tests/06_Query/QOM/Sql2TestQueries.php
+++ b/tests/06_Query/QOM/Sql2TestQueries.php
@@ -47,6 +47,41 @@ class Sql2TestQueries {
         $queries['6.7.11.DescendantNodeJoinCondition'] = 'SELECT * FROM [nt:file] INNER JOIN [nt:folder] ON ISDESCENDANTNODE(descendant, ancestor)';
 
         /**
+        * 6.7.12. Constraint (operator precedence)
+        */
+        $queries['6.7.12.Constraint.Precedence.1'] = array(
+            'SELECT * FROM [nt:file] WHERE sel1.prop1 = \'1\' OR sel1.prop2 = \'2\' AND sel1.prop3 = \'3\'',
+            'SELECT * FROM [nt:file] WHERE (sel1.prop1 = \'1\' OR (sel1.prop2 = \'2\' AND sel1.prop3 = \'3\'))',
+        );
+        $queries['6.7.12.Constraint.Precedence.2'] = array(
+            'SELECT * FROM [nt:file] WHERE sel1.prop1 = \'1\' AND sel1.prop2 = \'2\' OR sel1.prop3 = \'3\'',
+            'SELECT * FROM [nt:file] WHERE ((sel1.prop1 = \'1\' AND sel1.prop2 = \'2\') OR sel1.prop3 = \'3\')',
+        );
+
+        $queries['6.7.12.Constraint.Precedence.3'] = array(
+            'SELECT * FROM [nt:file] WHERE NOT sel1.prop1 = \'1\' OR sel1.prop2 = \'2\' AND NOT sel1.prop3 = \'3\'',
+            'SELECT * FROM [nt:file] WHERE (NOT sel1.prop1 = \'1\' OR (sel1.prop2 = \'2\' AND NOT sel1.prop3 = \'3\'))',
+        );
+
+        $queries['6.7.12.Constraint.Precedence.4'] = array(
+            'SELECT * FROM [nt:file] WHERE
+            sel1.prop1 IS NOT NULL AND sel1.prop2 IS NOT NULL
+                AND sel1.prop3 IS NOT NULL
+            OR sel1.prop4 IS NOT NULL AND sel1.prop5 IS NOT NULL
+                AND sel1.prop6 IS NOT NULL AND sel1.prop7 IS NOT NULL',
+
+            'SELECT * FROM [nt:file] WHERE (((sel1.prop1 IS NOT NULL AND sel1.prop2 IS NOT NULL) AND sel1.prop3 IS NOT NULL) OR (((sel1.prop4 IS NOT NULL AND sel1.prop5 IS NOT NULL) AND sel1.prop6 IS NOT NULL) AND sel1.prop7 IS NOT NULL))',
+        );
+
+        $queries['6.7.12.Constraint.Precedence.5'] = array(
+            'SELECT * FROM [nt:file] WHERE
+                NOT sel1.prop1 IS NOT NULL AND NOT NOT sel1.prop2 IS NOT NULL
+                OR NOT sel1.prop3 = \'hello\' AND sel1.prop4 <> \'hello\'',
+
+            'SELECT * FROM [nt:file] WHERE ((NOT sel1.prop1 IS NOT NULL AND NOT NOT sel1.prop2 IS NOT NULL) OR (NOT sel1.prop3 = \'hello\' AND sel1.prop4 <> \'hello\'))',
+        );
+
+        /**
         * 6.7.13. AndConstraint
         */
         $queries['6.7.13.And'] = array(


### PR DESCRIPTION
This PR adds some basic tests to check if the operator precedence is correctly implemented. See phpcr/phpcr-utils#12 for additional details.

I'm not sure if it's okay to put the test in to the `$queries`-array - I'd be happy to move the tests into their own test-case if that would be a better place.
