### PR TITLE
Moved a test from phpcr-utils to phpcr-api-tests, 

### DIFF
--- a/tests/06_Query/QOM/Sql2ToQomConverterTest.php
+++ b/tests/06_Query/QOM/Sql2ToQomConverterTest.php
@@ -75,4 +75,18 @@ class Sql2ToQomConverterTest extends \PHPCR\Test\BaseCase
             }
         }
     }
+
+    public function testPropertyComparisonWithWhitespace()
+    {
+        $sql2 = 'SELECT * FROM [nt:file] WHERE prop1 = "Foo bar"';
+
+        $qom = $this->parser->parse($sql2);
+
+        $this->assertInstanceOf('PHPCR\Query\QOM\ComparisonInterface', $qom->getConstraint());
+        $this->assertInstanceOf('PHPCR\Query\QOM\PropertyValueInterface', $qom->getConstraint()->getOperand1());
+        $this->assertInstanceOf('PHPCR\Query\QOM\LiteralInterface', $qom->getConstraint()->getOperand2());
+
+        $this->assertEquals('prop1', $qom->getConstraint()->getOperand1()->getPropertyName());
+        $this->assertEquals('Foo bar', $qom->getConstraint()->getOperand2()->getLiteralValue());
+    }
 }


### PR DESCRIPTION
It reveals an issue with parsing literals. It removes spaces from the literal.

The test was moved from this commit: https://github.com/phpcr/phpcr-utils/commit/05271b62e771823fb505d4797831cad474a03461
The other tests are already covered in this TestCase.
