### PR TITLE
Added test for reusing a path with a different Identifier

### DIFF
--- a/fixtures/10_Writing/delete.xml
+++ b/fixtures/10_Writing/delete.xml
@@ -230,6 +230,24 @@
     </sv:node>
   </sv:node>
 
+    <sv:node sv:name="testDeleteNodeAndReusePathWithReference">
+        <sv:property sv:name="jcr:primaryType" sv:type="Name">
+            <sv:value>nt:unstructured</sv:value>
+        </sv:property>
+
+        <sv:node sv:name="idExample">
+            <sv:property sv:name="jcr:primaryType" sv:type="Name">
+                <sv:value>nt:unstructured</sv:value>
+            </sv:property>
+            <sv:property sv:name="jcr:mixinTypes" sv:type="Name">
+                <sv:value>mix:referenceable</sv:value>
+            </sv:property>
+            <sv:property sv:name="jcr:uuid" sv:type="String">
+                <sv:value>cbc172b2-c317-44ac-a73b-1df61c35fb1a</sv:value>
+            </sv:property>
+        </sv:node>
+    </sv:node>
+
     <sv:node sv:name="testWorkspaceDelete">
         <sv:property sv:name="jcr:primaryType" sv:type="Name">
             <sv:value>nt:unstructured</sv:value>


### PR DESCRIPTION
This test demonstrates an issue found in Jackalope Doctrine DBAL: https://github.com/jackalope/jackalope-doctrine-dbal/pull/158
