### PR TITLE
add tests for mix:lastModified and handling for implementation loader

### DIFF
--- a/fixtures/10_Writing/lastmodified.xml
+++ b/fixtures/10_Writing/lastmodified.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sv:node xmlns:crx="http://www.day.com/crx/1.0" xmlns:mix="http://www.jcp.org/jcr/mix/1.0"
+         xmlns:nt="http://www.jcp.org/jcr/nt/1.0" xmlns:fn="http://www.w3.org/2005/xpath-functions"
+         xmlns:fn_old="http://www.w3.org/2004/10/xpath-functions" xmlns:vlt="http://www.day.com/jcr/vault/1.0"
+         xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+         xmlns:sv="http://www.jcp.org/jcr/sv/1.0" xmlns:rep="internal" sv:name="tests_write_manipulation_add">
+    <sv:property sv:name="jcr:primaryType" sv:type="Name">
+        <sv:value>nt:unstructured</sv:value>
+    </sv:property>
+    <sv:property sv:name="jcr:created" sv:type="Date">
+        <sv:value>2009-04-27T13:00:54.082+02:00</sv:value>
+    </sv:property>
+    <sv:node sv:name="testCreate">
+        <sv:property sv:name="jcr:primaryType" sv:type="Name">
+            <sv:value>nt:unstructured</sv:value>
+        </sv:property>
+    </sv:node>
+    <sv:node sv:name="testCreateManual">
+        <sv:property sv:name="jcr:primaryType" sv:type="Name">
+            <sv:value>nt:unstructured</sv:value>
+        </sv:property>
+    </sv:node>
+    <sv:node sv:name="testUpdateText">
+        <sv:property sv:name="jcr:primaryType" sv:type="Name">
+            <sv:value>nt:unstructured</sv:value>
+        </sv:property>
+        <sv:property sv:name="jcr:mixinTypes" sv:type="Name">
+            <sv:value>mix:lastModified</sv:value>
+        </sv:property>
+        <sv:property sv:name="jcr:lastModified" sv:type="Date">
+            <sv:value>2011-05-20T08:20:30.108+02:00</sv:value>
+        </sv:property>
+        <sv:property sv:name="jcr:lastModifiedBy" sv:type="String">
+            <sv:value>_phpcr-api-tests</sv:value>
+        </sv:property>
+        <sv:property sv:name="text" sv:type="String">
+            <sv:value>old</sv:value>
+        </sv:property>
+    </sv:node>
+    <sv:node sv:name="testUpdateManual">
+        <sv:property sv:name="jcr:primaryType" sv:type="Name">
+            <sv:value>nt:unstructured</sv:value>
+        </sv:property>
+        <sv:property sv:name="jcr:mixinTypes" sv:type="Name">
+            <sv:value>mix:lastModified</sv:value>
+        </sv:property>
+        <sv:property sv:name="jcr:lastModified" sv:type="Date">
+            <sv:value>2011-05-20T08:20:30.108+02:00</sv:value>
+        </sv:property>
+        <sv:property sv:name="jcr:lastModifiedBy" sv:type="String">
+            <sv:value>_phpcr-api-tests</sv:value>
+        </sv:property>
+        <sv:property sv:name="text" sv:type="String">
+            <sv:value>old</sv:value>
+        </sv:property>
+    </sv:node>
+    <sv:node sv:name="testUpdateBinary">
+        <sv:property sv:name="jcr:primaryType" sv:type="Name">
+            <sv:value>nt:unstructured</sv:value>
+        </sv:property>
+        <sv:property sv:name="jcr:mixinTypes" sv:type="Name">
+            <sv:value>mix:lastModified</sv:value>
+        </sv:property>
+        <sv:property sv:name="jcr:lastModified" sv:type="Date">
+            <sv:value>2011-05-20T08:20:30.108+02:00</sv:value>
+        </sv:property>
+        <sv:property sv:name="jcr:lastModifiedBy" sv:type="String">
+            <sv:value>_phpcr-api-tests</sv:value>
+        </sv:property>
+        <sv:property sv:name="binary-data" sv:type="Binary">
+            <sv:value>aDEuIENoYXB0ZXIgMSBUaXRsZQoKKiBmb28KKiBiYXIKKiogZm9vMgoqKiBmb28zCiogZm9vMAoKfHwgaGVhZGVyIHx8IGJhciB8fAp8IGggfCBqIHwKCntjb2RlfQpoZWxsbyB3b3JsZAp7Y29kZX0KCiMgZm9vCg==</sv:value>
+        </sv:property>
+    </sv:node>
+    <sv:node sv:name="testRemoveProperty">
+        <sv:property sv:name="jcr:primaryType" sv:type="Name">
+            <sv:value>nt:unstructured</sv:value>
+        </sv:property>
+        <sv:property sv:name="jcr:mixinTypes" sv:type="Name">
+            <sv:value>mix:lastModified</sv:value>
+        </sv:property>
+        <sv:property sv:name="jcr:lastModified" sv:type="Date">
+            <sv:value>2011-05-20T08:20:30.108+02:00</sv:value>
+        </sv:property>
+        <sv:property sv:name="jcr:lastModifiedBy" sv:type="String">
+            <sv:value>_phpcr-api-tests</sv:value>
+        </sv:property>
+        <sv:property sv:name="text" sv:type="String">
+            <sv:value>old</sv:value>
+        </sv:property>
+    </sv:node>
+</sv:node>

--- a/inc/AbstractLoader.php
+++ b/inc/AbstractLoader.php
@@ -177,6 +177,39 @@ abstract class AbstractLoader
     }
 
     /**
+     * If the implementation can automatically update mix:lastModified nodes,
+     * this should return a session configured to do that.
+     *
+     * Otherwise, the test regarding this feature is skipped.
+     *
+     * @return \PHPCR\SessionInterface
+     *
+     * @throws \PHPUnit_Framework_SkippedTestSuiteError to make whole test
+     *      suite skip if implementation does not support updating the
+     *      properties automatically.
+     */
+    public function getSessionWithLastModified()
+    {
+        if ($this->doesSessionLastModified()) {
+            return $this->getSession();
+        }
+
+        throw new \PHPUnit_Framework_SkippedTestSuiteError('Not supported');
+    }
+
+    /**
+     * The implementation loader should provide a session that does not update
+     * mix:lastModified. If that is not possible, this method should return
+     * true, which will skip the test about this feature.
+     *
+     * @return boolean
+     */
+    public function doesSessionLastModified()
+    {
+        return false;
+    }
+
+    /**
      * Decide whether this test can be executed.
      *
      * The default implementation uses the unsupported... arrays to decide.

--- a/inc/BaseCase.php
+++ b/inc/BaseCase.php
@@ -252,4 +252,21 @@ abstract class BaseCase extends \PHPUnit_Framework_TestCase
     {
         $this->assertEquals($date1->getTimestamp(), $date2->getTimestamp());
     }
+
+    /**
+     * Assert that both arguments are datetime and are within 3 seconds of each
+     * other. Use this rather than plain "Equal" when checking application
+     * generated dates.
+     *
+     * @param \DateTime $expected
+     * @param \DateTime $data
+     */
+    protected function assertSimilarDateTime($expected, $data)
+    {
+        $this->assertInstanceOf('\DateTime', $expected);
+        $this->assertInstanceOf('\DateTime', $data);
+        $this->assertTrue(abs($expected->getTimestamp() - $data->getTimestamp()) <= 3,
+            $data->format('c') . ' is not close to the expected ' . $expected->format('c')
+        );
+    }
 }

--- a/tests/10_Writing/LastModifiedTest.php
+++ b/tests/10_Writing/LastModifiedTest.php
@@ -1,0 +1,125 @@
+<?php
+namespace PHPCR\Tests\Writing;
+
+use Jackalope\Session;
+use PHPCR\PropertyInterface;
+
+require_once(__DIR__ . '/../../inc/BaseCase.php');
+
+/**
+ * Testing the mix:lastModified support when the values are never updated
+ * automatically.
+ */
+class LastModifiedTest extends \PHPCR\Test\BaseCase
+{
+    public static function setupBeforeClass($fixtures = '10_Writing/lastmodified')
+    {
+        parent::setupBeforeClass($fixtures);
+    }
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        if (self::$loader->doesSessionLastModified()) {
+            $this->markTestSkipped('Session updates lastModified automatically');
+        }
+    }
+
+    /**
+     * Add mixin to an existing and to a new node.
+     */
+    public function testCreate()
+    {
+        $this->assertFalse($this->node->hasProperty('jcr:lastModified'));
+        $this->node->addMixin('mix:lastModified');
+
+        $this->session->save();
+
+        $this->assertTrue($this->node->hasProperty('jcr:lastModifiedBy'));
+        $this->assertTrue($this->node->hasProperty('jcr:lastModified'));
+        $this->assertSimilarDateTime(new \DateTime(), $this->node->getPropertyValue('jcr:lastModified'));
+
+        $node = $this->node->addNode('child');
+        $node->addMixin('mix:lastModified');
+
+        $this->session->save();
+
+        $this->assertTrue($node->hasProperty('jcr:lastModifiedBy'));
+        $this->assertTrue($node->hasProperty('jcr:lastModified'));
+        $this->assertSimilarDateTime(new \DateTime(), $node->getPropertyValue('jcr:lastModified'));
+    }
+
+    /**
+     * When setting the lastModified information manually, it should not be
+     * overwritten.
+     */
+    public function testCreateManual()
+    {
+        $this->assertFalse($this->node->hasProperty('jcr:lastModified'));
+        $this->node->addMixin('mix:lastModified');
+        $this->node->setProperty('jcr:lastModifiedBy', 'me');
+
+        $this->session->save();
+
+        $this->assertTrue($this->node->hasProperty('jcr:lastModifiedBy'));
+        $this->assertEquals('me', $this->node->getPropertyValue('jcr:lastModifiedBy'));
+        $this->assertTrue($this->node->hasProperty('jcr:lastModified'));
+        $this->assertSimilarDateTime(new \DateTime(), $this->node->getPropertyValue('jcr:lastModified'));
+
+        $node = $this->node->addNode('child');
+        $node->addMixin('mix:lastModified');
+        $date = new \DateTime('2012-01-02');
+        $node->setProperty('jcr:lastModified', $date);
+
+        $this->session->save();
+
+        $this->assertTrue($node->hasProperty('jcr:lastModifiedBy'));
+        $this->assertTrue($node->hasProperty('jcr:lastModified'));
+        $this->assertEqualDateTime($date, $node->getPropertyValue('jcr:lastModified'));
+    }
+
+    public function testUpdateText()
+    {
+        $date = $this->node->getPropertyValue('jcr:lastModified');
+        $this->node->setProperty('text', 'new');
+
+        $this->session->save();
+
+        $this->assertEqualDateTime($date, $this->node->getPropertyValue('jcr:lastModified'));
+    }
+
+    public function testUpdateManual()
+    {
+        $date = new \DateTime('2013-10-10');
+        $this->node->setProperty('jcr:lastModified', $date);
+        $this->node->setProperty('text', 'new');
+
+        $this->session->save();
+
+        $this->assertEqualDateTime($date, $this->node->getPropertyValue('jcr:lastModified'));
+    }
+
+    public function testUpdateBinary()
+    {
+        $date = $this->node->getPropertyValue('jcr:lastModified');
+        $stream = fopen('php://memory', 'w+');
+        fwrite($stream, 'foo bar');
+        rewind($stream);
+        $this->node->setProperty('binary-data', $stream);
+
+        $this->session->save();
+
+        $this->assertEqualDateTime($date, $this->node->getPropertyValue('jcr:lastModified'));
+    }
+
+    public function testRemoveProperty()
+    {
+        $date = $this->node->getPropertyValue('jcr:lastModified');
+        $this->node->setProperty('text', null);
+
+        $this->session->save();
+
+        $this->assertEqualDateTime($date, $this->node->getPropertyValue('jcr:lastModified'));
+    }
+}

--- a/tests/10_Writing/LastModifiedUpdateTest.php
+++ b/tests/10_Writing/LastModifiedUpdateTest.php
@@ -1,0 +1,120 @@
+<?php
+namespace PHPCR\Tests\Writing;
+
+use Jackalope\Session;
+use PHPCR\PropertyInterface;
+
+require_once(__DIR__ . '/../../inc/BaseCase.php');
+
+/**
+ * Testing the mix:lastModified support when properties should be updated
+ * automatically.
+ *
+ * We do not enforce the update for the WorkspaceInterface::removeItem
+ * operation. If the implementation can do that without performance loss, it
+ * may update the date, but it is not forced to, as this is potentially quite
+ * expensive.
+ */
+class LastModifiedUpdateTest extends \PHPCR\Test\BaseCase
+{
+    public static function setupBeforeClass($fixtures = '10_Writing/lastmodified')
+    {
+        parent::setupBeforeClass($fixtures);
+
+        self::$staticSharedFixture['session'] = self::$loader->getSessionWithLastModified();
+    }
+
+    /**
+     * Add mixin to an existing and to a new node.
+     */
+    public function testCreate()
+    {
+        $this->assertFalse($this->node->hasProperty('jcr:lastModified'));
+        $this->node->addMixin('mix:lastModified');
+
+        $this->session->save();
+
+        $this->assertTrue($this->node->hasProperty('jcr:lastModifiedBy'));
+        $this->assertTrue($this->node->hasProperty('jcr:lastModified'));
+        $this->assertSimilarDateTime(new \DateTime(), $this->node->getPropertyValue('jcr:lastModified'));
+
+        $node = $this->node->addNode('child');
+        $node->addMixin('mix:lastModified');
+
+        $this->session->save();
+
+        $this->assertTrue($node->hasProperty('jcr:lastModifiedBy'));
+        $this->assertTrue($node->hasProperty('jcr:lastModified'));
+        $this->assertSimilarDateTime(new \DateTime(), $node->getPropertyValue('jcr:lastModified'));
+    }
+
+    /**
+     * When setting the lastModified information manually, it should not be
+     * overwritten.
+     */
+    public function testCreateManual()
+    {
+        $this->assertFalse($this->node->hasProperty('jcr:lastModified'));
+        $this->node->addMixin('mix:lastModified');
+        $this->node->setProperty('jcr:lastModifiedBy', 'me');
+
+        $this->session->save();
+
+        $this->assertTrue($this->node->hasProperty('jcr:lastModifiedBy'));
+        $this->assertEquals('me', $this->node->getPropertyValue('jcr:lastModifiedBy'));
+        $this->assertTrue($this->node->hasProperty('jcr:lastModified'));
+        $this->assertSimilarDateTime(new \DateTime(), $this->node->getPropertyValue('jcr:lastModified'));
+
+        $node = $this->node->addNode('child');
+        $node->addMixin('mix:lastModified');
+        $date = new \DateTime('2012-01-02');
+        $node->setProperty('jcr:lastModified', $date);
+
+        $this->session->save();
+
+        $this->assertTrue($node->hasProperty('jcr:lastModifiedBy'));
+        $this->assertTrue($node->hasProperty('jcr:lastModified'));
+        $this->assertEqualDateTime($date, $node->getPropertyValue('jcr:lastModified'));
+    }
+
+    public function testUpdateText()
+    {
+        $this->node->setProperty('text', 'new');
+
+        $this->session->save();
+
+        $this->assertSimilarDateTime(new \DateTime(), $this->node->getPropertyValue('jcr:lastModified'));
+    }
+
+    public function testUpdateManual()
+    {
+        $date = new \DateTime('2013-10-10');
+        $this->node->setProperty('jcr:lastModified', $date);
+        $this->node->setProperty('text', 'new');
+
+        $this->session->save();
+
+        $this->assertEqualDateTime($date, $this->node->getPropertyValue('jcr:lastModified'));
+    }
+
+    public function testUpdateBinary()
+    {
+        $stream = fopen('php://memory', 'w+');
+        fwrite($stream, 'foo bar');
+        rewind($stream);
+        $this->node->setProperty('binary-data', $stream);
+
+        $this->session->save();
+
+        $this->assertSimilarDateTime(new \DateTime(), $this->node->getPropertyValue('jcr:lastModified'));
+    }
+
+    public function testRemoveProperty()
+    {
+        $this->node->setProperty('text', null);
+
+        $this->session->save();
+
+        $this->assertSimilarDateTime(new \DateTime(), $this->node->getPropertyValue('jcr:lastModified'));
+    }
+}


### PR DESCRIPTION
tests around the behaviour with mix:lastModified

this complements https://github.com/jackalope/jackalope/pull/201 but should just lead to skipped tests if nothing is done
