### PR TITLE
Added tests to ensure copied references are consistent

### DIFF
--- a/fixtures/10_Writing/copy.xml
+++ b/fixtures/10_Writing/copy.xml
@@ -28,15 +28,15 @@
                     <sv:value>nt:unstructured</sv:value>
                 </sv:property>
 
-                <sv:property sv:name="block_1" sv:type="Reference">
+                <sv:property sv:name="block_1_ref" sv:type="Reference">
                     <sv:value>00000000-0000-0000-0000-000000000001</sv:value>
                 </sv:property>
 
-                <sv:property sv:name="block_2" sv:type="Reference">
+                <sv:property sv:name="block_2_ref" sv:type="Reference">
                     <sv:value>00000000-0000-0000-0000-000000000002</sv:value>
                 </sv:property>
 
-                <sv:property sv:name="block_3" sv:type="WeakReference">
+                <sv:property sv:name="block_3_ref" sv:type="WeakReference">
                     <sv:value>00000000-0000-0000-0000-000000000003</sv:value>
                 </sv:property>
 
@@ -86,7 +86,7 @@
 
         <sv:node sv:name="srcNode">
             <sv:property sv:name="jcr:primaryType" sv:type="Name">
-                <sv:value>nt:folder</sv:value>
+                <sv:value>nt:unstructured</sv:value>
             </sv:property>
             <sv:property sv:name="jcr:mixinTypes" sv:type="Name">
                 <sv:value>mix:referenceable</sv:value>
@@ -130,7 +130,7 @@
         </sv:node>
         <sv:node sv:name="dstNode">
             <sv:property sv:name="jcr:primaryType" sv:type="Name">
-                <sv:value>nt:folder</sv:value>
+                <sv:value>nt:unstructured</sv:value>
             </sv:property>
             <sv:property sv:name="jcr:created" sv:type="Date">
                 <sv:value>2011-05-20T08:23:35.640+02:00</sv:value>

--- a/fixtures/10_Writing/copy.xml
+++ b/fixtures/10_Writing/copy.xml
@@ -1,348 +1,424 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <sv:node xmlns:crx="http://www.day.com/crx/1.0" xmlns:mix="http://www.jcp.org/jcr/mix/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0" xmlns:fn="http://www.w3.org/2005/xpath-functions" xmlns:fn_old="http://www.w3.org/2004/10/xpath-functions" xmlns:vlt="http://www.day.com/jcr/vault/1.0" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:sv="http://www.jcp.org/jcr/sv/1.0" xmlns:rep="internal" sv:name="tests_write_manipulation_copy">
-  <sv:property sv:name="jcr:primaryType" sv:type="Name">
-    <sv:value>nt:unstructured</sv:value>
-  </sv:property>
-  <sv:property sv:name="jcr:created" sv:type="Date">
-    <sv:value>2009-04-27T13:00:54.082+02:00</sv:value>
-  </sv:property>
-  <sv:node sv:name="testWorkspaceCopy">
     <sv:property sv:name="jcr:primaryType" sv:type="Name">
-      <sv:value>nt:unstructured</sv:value>
-    </sv:property>
-    <sv:node sv:name="srcNode">
-      <sv:property sv:name="jcr:primaryType" sv:type="Name">
-        <sv:value>nt:folder</sv:value>
-      </sv:property>
-      <sv:property sv:name="jcr:mixinTypes" sv:type="Name">
-        <sv:value>mix:referenceable</sv:value>
-      </sv:property>
-      <sv:property sv:name="jcr:uuid" sv:type="String">
-        <sv:value>842e61c0-09ab-42a9-87c0-308ccc90e6f6</sv:value>
-      </sv:property>
-      <sv:node sv:name="srcFile">
-        <sv:property sv:name="jcr:primaryType" sv:type="Name">
-          <sv:value>nt:file</sv:value>
-        </sv:property>
-        <sv:property sv:name="jcr:mixinTypes" sv:type="Name">
-          <sv:value>mix:referenceable</sv:value>
-        </sv:property>
-        <sv:property sv:name="jcr:created" sv:type="Date">
-          <sv:value>2011-05-20T08:23:35.640+02:00</sv:value>
-        </sv:property>
-        <sv:property sv:name="jcr:createdBy" sv:type="String">
-          <sv:value>admin</sv:value>
-        </sv:property>
-        <sv:node sv:name="jcr:content">
-          <sv:property sv:name="jcr:primaryType" sv:type="Name">
-            <sv:value>nt:unstructured</sv:value>
-          </sv:property>
-          <sv:property sv:name="jcr:data" sv:type="String">
-            <sv:value>aDEuIENoYXB0ZXIgMSBUaXRsZQoKCiogZm9vCiogYmFyCioqIGZvbzIKKiogZm9vMwoqIGZvbzAKCnx8IGhlYWRlciB8fCBiYXIgfHwKfCBoIHwgaiB8IAoKW0Zvb3wgaHR0cDovL2xpaXAuY2hdCgp7Y29kZX0KaGVsbG8gd29ybGQKe2NvZGV9CgojIGZvbwojIGIKCgpoMi4gU2VjdGlvbiAxLjEgVGl0bGUKCgpTdWJzZWN0aW9uIDEuMS4xIFRpdGxlCn5+fn5+fn5+fn5+fn5+fn5+fn5+fn4KClNlY3Rpb24gMS4yIFRpdGxlCi0tLS0tLS0tLS0tLS0tLS0tCgpDaGFwdGVyIDIgVGl0bGUKPT09PT09PT09PT09PT09Cg==</sv:value>
-          </sv:property>
-          <sv:property sv:name="jcr:lastModified" sv:type="Date">
-            <sv:value>2009-04-27T13:01:07.472+02:00</sv:value>
-          </sv:property>
-          <sv:property sv:name="jcr:mimeType" sv:type="String">
-            <sv:value>text/plain</sv:value>
-          </sv:property>
-          <sv:property sv:name="someProperty" sv:type="String">
-            <sv:value>yo</sv:value>
-          </sv:property>
-        </sv:node>
-      </sv:node>
-    </sv:node>
-    <sv:node sv:name="dstNode">
-      <sv:property sv:name="jcr:primaryType" sv:type="Name">
-        <sv:value>nt:folder</sv:value>
-      </sv:property>
-      <sv:property sv:name="jcr:created" sv:type="Date">
-        <sv:value>2011-05-20T08:23:35.640+02:00</sv:value>
-      </sv:property>
-      <sv:property sv:name="jcr:createdBy" sv:type="String">
-        <sv:value>admin</sv:value>
-      </sv:property>
-    </sv:node>
-  </sv:node>
-  <sv:node sv:name="testWorkspaceCopyOther">
-    <sv:property sv:name="jcr:primaryType" sv:type="Name">
-      <sv:value>nt:unstructured</sv:value>
-    </sv:property>
-  </sv:node>
-  <sv:node sv:name="testCopyProperty">
-    <sv:property sv:name="jcr:primaryType" sv:type="Name">
-      <sv:value>nt:folder</sv:value>
+        <sv:value>nt:unstructured</sv:value>
     </sv:property>
     <sv:property sv:name="jcr:created" sv:type="Date">
-      <sv:value>2011-05-20T08:23:35.643+02:00</sv:value>
+        <sv:value>2009-04-27T13:00:54.082+02:00</sv:value>
     </sv:property>
-    <sv:property sv:name="jcr:createdBy" sv:type="String">
-      <sv:value>admin</sv:value>
-    </sv:property>
-    <sv:node sv:name="srcFile">
-      <sv:property sv:name="jcr:primaryType" sv:type="Name">
-        <sv:value>nt:file</sv:value>
-      </sv:property>
-      <sv:property sv:name="jcr:created" sv:type="Date">
-        <sv:value>2011-05-20T08:23:35.643+02:00</sv:value>
-      </sv:property>
-      <sv:property sv:name="jcr:createdBy" sv:type="String">
-        <sv:value>admin</sv:value>
-      </sv:property>
-      <sv:node sv:name="jcr:content">
+    <sv:node sv:name="testWorkspaceCopy">
         <sv:property sv:name="jcr:primaryType" sv:type="Name">
-          <sv:value>nt:unstructured</sv:value>
-        </sv:property>
-        <sv:property sv:name="jcr:data" sv:type="String">
-          <sv:value>aDEuIENoYXB0ZXIgMSBUaXRsZQoKCiogZm9vCiogYmFyCioqIGZvbzIKKiogZm9vMwoqIGZvbzAKCnx8IGhlYWRlciB8fCBiYXIgfHwKfCBoIHwgaiB8IAoKW0Zvb3wgaHR0cDovL2xpaXAuY2hdCgp7Y29kZX0KaGVsbG8gd29ybGQKe2NvZGV9CgojIGZvbwojIGIKCgpoMi4gU2VjdGlvbiAxLjEgVGl0bGUKCgpTdWJzZWN0aW9uIDEuMS4xIFRpdGxlCn5+fn5+fn5+fn5+fn5+fn5+fn5+fn4KClNlY3Rpb24gMS4yIFRpdGxlCi0tLS0tLS0tLS0tLS0tLS0tCgpDaGFwdGVyIDIgVGl0bGUKPT09PT09PT09PT09PT09Cg==</sv:value>
-        </sv:property>
-        <sv:property sv:name="jcr:lastModified" sv:type="Date">
-          <sv:value>2009-04-27T13:01:07.472+02:00</sv:value>
-        </sv:property>
-        <sv:property sv:name="jcr:mimeType" sv:type="String">
-          <sv:value>text/plain</sv:value>
-        </sv:property>
-        <sv:property sv:name="someProperty" sv:type="String">
-          <sv:value>yo</sv:value>
-        </sv:property>
-      </sv:node>
-    </sv:node>
-    <sv:node sv:name="dstFile">
-      <sv:property sv:name="jcr:primaryType" sv:type="Name">
-        <sv:value>nt:file</sv:value>
-      </sv:property>
-      <sv:property sv:name="jcr:created" sv:type="Date">
-        <sv:value>2011-05-20T08:23:35.644+02:00</sv:value>
-      </sv:property>
-      <sv:property sv:name="jcr:createdBy" sv:type="String">
-        <sv:value>admin</sv:value>
-      </sv:property>
-      <sv:node sv:name="jcr:content">
-        <sv:property sv:name="jcr:primaryType" sv:type="Name">
-          <sv:value>nt:unstructured</sv:value>
-        </sv:property>
-        <sv:property sv:name="jcr:lastModified" sv:type="Date">
-          <sv:value>2009-04-27T13:01:07.472+02:00</sv:value>
-        </sv:property>
-        <sv:property sv:name="jcr:mimeType" sv:type="String">
-          <sv:value>text/plain</sv:value>
-        </sv:property>
-      </sv:node>
-    </sv:node>
-  </sv:node>
-  <sv:node sv:name="testCopyInvalidDstPath">
-    <sv:property sv:name="jcr:primaryType" sv:type="Name">
-      <sv:value>nt:unstructured</sv:value>
-    </sv:property>
-    <sv:node sv:name="srcNode">
-      <sv:property sv:name="jcr:primaryType" sv:type="Name">
-        <sv:value>nt:folder</sv:value>
-      </sv:property>
-      <sv:property sv:name="jcr:created" sv:type="Date">
-        <sv:value>2011-05-20T08:23:35.645+02:00</sv:value>
-      </sv:property>
-      <sv:property sv:name="jcr:createdBy" sv:type="String">
-        <sv:value>admin</sv:value>
-      </sv:property>
-    </sv:node>
-    <sv:node sv:name="dstNode">
-      <sv:property sv:name="jcr:primaryType" sv:type="Name">
-        <sv:value>nt:folder</sv:value>
-      </sv:property>
-      <sv:property sv:name="jcr:created" sv:type="Date">
-        <sv:value>2011-05-20T08:23:35.645+02:00</sv:value>
-      </sv:property>
-      <sv:property sv:name="jcr:createdBy" sv:type="String">
-        <sv:value>admin</sv:value>
-      </sv:property>
-    </sv:node>
-  </sv:node>
-  <sv:node sv:name="testCopySrcNotFound">
-    <sv:property sv:name="jcr:primaryType" sv:type="Name">
-      <sv:value>nt:unstructured</sv:value>
-    </sv:property>
-    <sv:node sv:name="dstNode">
-      <sv:property sv:name="jcr:primaryType" sv:type="Name">
-        <sv:value>nt:folder</sv:value>
-      </sv:property>
-      <sv:property sv:name="jcr:created" sv:type="Date">
-        <sv:value>2011-05-20T08:23:35.645+02:00</sv:value>
-      </sv:property>
-      <sv:property sv:name="jcr:createdBy" sv:type="String">
-        <sv:value>admin</sv:value>
-      </sv:property>
-    </sv:node>
-  </sv:node>
-  <sv:node sv:name="testCopyDstParentNotFound">
-    <sv:property sv:name="jcr:primaryType" sv:type="Name">
-      <sv:value>nt:unstructured</sv:value>
-    </sv:property>
-    <sv:node sv:name="srcNode">
-      <sv:property sv:name="jcr:primaryType" sv:type="Name">
-        <sv:value>nt:folder</sv:value>
-      </sv:property>
-      <sv:property sv:name="jcr:created" sv:type="Date">
-        <sv:value>2011-05-20T08:23:35.645+02:00</sv:value>
-      </sv:property>
-      <sv:property sv:name="jcr:createdBy" sv:type="String">
-        <sv:value>admin</sv:value>
-      </sv:property>
-    </sv:node>
-    <sv:node sv:name="dstNode">
-      <sv:property sv:name="jcr:primaryType" sv:type="Name">
-        <sv:value>nt:folder</sv:value>
-      </sv:property>
-      <sv:property sv:name="jcr:created" sv:type="Date">
-        <sv:value>2011-05-20T08:23:35.645+02:00</sv:value>
-      </sv:property>
-      <sv:property sv:name="jcr:createdBy" sv:type="String">
-        <sv:value>admin</sv:value>
-      </sv:property>
-    </sv:node>
-  </sv:node>
-  <sv:node sv:name="testCopyNoUpdateOnCopy">
-    <sv:property sv:name="jcr:primaryType" sv:type="Name">
-      <sv:value>nt:unstructured</sv:value>
-    </sv:property>
-    <sv:node sv:name="srcNode">
-      <sv:property sv:name="jcr:primaryType" sv:type="Name">
-        <sv:value>nt:folder</sv:value>
-      </sv:property>
-      <sv:property sv:name="jcr:created" sv:type="Date">
-        <sv:value>2011-05-20T08:23:35.645+02:00</sv:value>
-      </sv:property>
-      <sv:property sv:name="jcr:createdBy" sv:type="String">
-        <sv:value>admin</sv:value>
-      </sv:property>
-    </sv:node>
-    <sv:node sv:name="dstNode">
-      <sv:property sv:name="jcr:primaryType" sv:type="Name">
-        <sv:value>nt:folder</sv:value>
-      </sv:property>
-      <sv:property sv:name="jcr:created" sv:type="Date">
-        <sv:value>2011-05-20T08:23:35.645+02:00</sv:value>
-      </sv:property>
-      <sv:property sv:name="jcr:createdBy" sv:type="String">
-        <sv:value>admin</sv:value>
-      </sv:property>
-      <sv:node sv:name="srcNode">
-        <sv:property sv:name="jcr:primaryType" sv:type="Name">
-          <sv:value>nt:folder</sv:value>
-        </sv:property>
-        <sv:property sv:name="jcr:created" sv:type="Date">
-          <sv:value>2011-05-20T08:23:35.646+02:00</sv:value>
-        </sv:property>
-        <sv:property sv:name="jcr:createdBy" sv:type="String">
-          <sv:value>admin</sv:value>
-        </sv:property>
-      </sv:node>
-    </sv:node>
-  </sv:node>
-  <sv:node sv:name="testCopyUpdateOnCopy">
-    <sv:property sv:name="jcr:primaryType" sv:type="Name">
-      <sv:value>nt:unstructured</sv:value>
-    </sv:property>
-    <sv:node sv:name="srcNode">
-      <sv:property sv:name="jcr:primaryType" sv:type="Name">
-        <sv:value>nt:folder</sv:value>
-      </sv:property>
-      <sv:property sv:name="jcr:created" sv:type="Date">
-        <sv:value>2011-05-20T08:23:35.646+02:00</sv:value>
-      </sv:property>
-      <sv:property sv:name="jcr:createdBy" sv:type="String">
-        <sv:value>admin</sv:value>
-      </sv:property>
-      <sv:node sv:name="srcFile">
-        <sv:property sv:name="jcr:primaryType" sv:type="Name">
-          <sv:value>nt:file</sv:value>
-        </sv:property>
-        <sv:property sv:name="jcr:created" sv:type="Date">
-          <sv:value>2011-05-20T08:23:35.646+02:00</sv:value>
-        </sv:property>
-        <sv:property sv:name="jcr:createdBy" sv:type="String">
-          <sv:value>admin</sv:value>
-        </sv:property>
-        <sv:node sv:name="jcr:content">
-          <sv:property sv:name="jcr:primaryType" sv:type="Name">
             <sv:value>nt:unstructured</sv:value>
-          </sv:property>
-          <sv:property sv:name="jcr:data" sv:type="String">
-            <sv:value>aDEuIENoYXB0ZXIgMSBUaXRsZQoKCiogZm9vCiogYmFyCioqIGZvbzIKKiogZm9vMwoqIGZvbzAKCnx8IGhlYWRlciB8fCBiYXIgfHwKfCBoIHwgaiB8IAoKW0Zvb3wgaHR0cDovL2xpaXAuY2hdCgp7Y29kZX0KaGVsbG8gd29ybGQKe2NvZGV9CgojIGZvbwojIGIKCgpoMi4gU2VjdGlvbiAxLjEgVGl0bGUKCgpTdWJzZWN0aW9uIDEuMS4xIFRpdGxlCn5+fn5+fn5+fn5+fn5+fn5+fn5+fn4KClNlY3Rpb24gMS4yIFRpdGxlCi0tLS0tLS0tLS0tLS0tLS0tCgpDaGFwdGVyIDIgVGl0bGUKPT09PT09PT09PT09PT09Cg==</sv:value>
-          </sv:property>
-          <sv:property sv:name="jcr:lastModified" sv:type="Date">
-            <sv:value>2009-04-27T13:01:07.472+02:00</sv:value>
-          </sv:property>
-          <sv:property sv:name="jcr:mimeType" sv:type="String">
-            <sv:value>text/plain</sv:value>
-          </sv:property>
-        </sv:node>
-      </sv:node>
-      <sv:node sv:name="updateFile">
-        <sv:property sv:name="jcr:primaryType" sv:type="Name">
-          <sv:value>nt:file</sv:value>
         </sv:property>
-        <sv:property sv:name="jcr:created" sv:type="Date">
-          <sv:value>2011-05-20T08:23:35.646+02:00</sv:value>
-        </sv:property>
-        <sv:property sv:name="jcr:createdBy" sv:type="String">
-          <sv:value>admin</sv:value>
-        </sv:property>
-        <sv:node sv:name="jcr:content">
-          <sv:property sv:name="jcr:primaryType" sv:type="Name">
-            <sv:value>nt:unstructured</sv:value>
-          </sv:property>
-          <sv:property sv:name="jcr:data" sv:type="String">
-            <sv:value>123</sv:value>
-          </sv:property>
-          <sv:property sv:name="jcr:mimeType" sv:type="String">
-            <sv:value>text/plain</sv:value>
-          </sv:property>
-        </sv:node>
-      </sv:node>
-    </sv:node>
-    <sv:node sv:name="dstNode">
-      <sv:property sv:name="jcr:primaryType" sv:type="Name">
-        <sv:value>nt:folder</sv:value>
-      </sv:property>
-      <sv:property sv:name="jcr:created" sv:type="Date">
-        <sv:value>2011-05-20T08:23:35.647+02:00</sv:value>
-      </sv:property>
-      <sv:property sv:name="jcr:createdBy" sv:type="String">
-        <sv:value>admin</sv:value>
-      </sv:property>
-      <sv:node sv:name="srcNode">
-        <sv:property sv:name="jcr:primaryType" sv:type="Name">
-          <sv:value>nt:folder</sv:value>
-        </sv:property>
-        <sv:property sv:name="jcr:created" sv:type="Date">
-          <sv:value>2011-05-20T08:23:35.647+02:00</sv:value>
-        </sv:property>
-        <sv:property sv:name="jcr:createdBy" sv:type="String">
-          <sv:value>admin</sv:value>
-        </sv:property>
-        <sv:node sv:name="updateFile">
-          <sv:property sv:name="jcr:primaryType" sv:type="Name">
-            <sv:value>nt:file</sv:value>
-          </sv:property>
-          <sv:property sv:name="jcr:created" sv:type="Date">
-            <sv:value>2011-05-20T08:23:35.647+02:00</sv:value>
-          </sv:property>
-          <sv:property sv:name="jcr:createdBy" sv:type="String">
-            <sv:value>admin</sv:value>
-          </sv:property>
-          <sv:node sv:name="jcr:content">
+
+        <sv:node sv:name="referencedNodeSet">
             <sv:property sv:name="jcr:primaryType" sv:type="Name">
-              <sv:value>nt:unstructured</sv:value>
+                <sv:value>nt:unstructured</sv:value>
             </sv:property>
-            <sv:property sv:name="jcr:data" sv:type="String">
-              <sv:value>1</sv:value>
+            <sv:property sv:name="jcr:mixinTypes" sv:type="Name">
+                <sv:value>mix:referenceable</sv:value>
             </sv:property>
-            <sv:property sv:name="jcr:mimeType" sv:type="String">
-              <sv:value>text/plain</sv:value>
+            <sv:property sv:name="jcr:uuid" sv:type="String">
+                <sv:value>33343533-09ab-42a9-87c0-308ccc90e6f6</sv:value>
             </sv:property>
-          </sv:node>
+
+            <sv:node sv:name="home">
+
+                <sv:property sv:name="jcr:primaryType" sv:type="Name">
+                    <sv:value>nt:unstructured</sv:value>
+                </sv:property>
+
+                <sv:property sv:name="block_1" sv:type="Reference">
+                    <sv:value>00000000-0000-0000-0000-000000000001</sv:value>
+                </sv:property>
+
+                <sv:property sv:name="block_2" sv:type="Reference">
+                    <sv:value>00000000-0000-0000-0000-000000000002</sv:value>
+                </sv:property>
+
+                <sv:property sv:name="block_3" sv:type="WeakReference">
+                    <sv:value>00000000-0000-0000-0000-000000000003</sv:value>
+                </sv:property>
+
+
+                <sv:property sv:name="external_reference" sv:type="Reference">
+                    <sv:value>842e61c0-09ab-42a9-87c0-308ccc90e6f6</sv:value>
+                </sv:property>
+
+                <sv:node sv:name="block_1">
+                    <sv:property sv:name="jcr:primaryType" sv:type="Name">
+                        <sv:value>nt:unstructured</sv:value>
+                    </sv:property>
+                    <sv:property sv:name="jcr:mixinTypes" sv:type="Name">
+                        <sv:value>mix:referenceable</sv:value>
+                    </sv:property>
+                    <sv:property sv:name="jcr:uuid" sv:type="String">
+                        <sv:value>00000000-0000-0000-0000-000000000001</sv:value>
+                    </sv:property>
+
+                    <sv:node sv:name="block_2">
+                        <sv:property sv:name="jcr:primaryType" sv:type="Name">
+                            <sv:value>nt:unstructured</sv:value>
+                        </sv:property>
+                        <sv:property sv:name="jcr:mixinTypes" sv:type="Name">
+                            <sv:value>mix:referenceable</sv:value>
+                        </sv:property>
+                        <sv:property sv:name="jcr:uuid" sv:type="String">
+                            <sv:value>00000000-0000-0000-0000-000000000002</sv:value>
+                        </sv:property>
+                    </sv:node>
+
+                    <sv:node sv:name="block_3">
+                        <sv:property sv:name="jcr:primaryType" sv:type="Name">
+                            <sv:value>nt:unstructured</sv:value>
+                        </sv:property>
+                        <sv:property sv:name="jcr:mixinTypes" sv:type="Name">
+                            <sv:value>mix:referenceable</sv:value>
+                        </sv:property>
+                        <sv:property sv:name="jcr:uuid" sv:type="String">
+                            <sv:value>00000000-0000-0000-0000-000000000003</sv:value>
+                        </sv:property>
+                    </sv:node>
+                </sv:node>
+            </sv:node>
+
         </sv:node>
-      </sv:node>
+
+        <sv:node sv:name="srcNode">
+            <sv:property sv:name="jcr:primaryType" sv:type="Name">
+                <sv:value>nt:folder</sv:value>
+            </sv:property>
+            <sv:property sv:name="jcr:mixinTypes" sv:type="Name">
+                <sv:value>mix:referenceable</sv:value>
+            </sv:property>
+            <sv:property sv:name="jcr:uuid" sv:type="String">
+                <sv:value>842e61c0-09ab-42a9-87c0-308ccc90e6f6</sv:value>
+            </sv:property>
+
+
+            <sv:node sv:name="srcFile">
+                <sv:property sv:name="jcr:primaryType" sv:type="Name">
+                    <sv:value>nt:file</sv:value>
+                </sv:property>
+                <sv:property sv:name="jcr:mixinTypes" sv:type="Name">
+                    <sv:value>mix:referenceable</sv:value>
+                </sv:property>
+                <sv:property sv:name="jcr:created" sv:type="Date">
+                    <sv:value>2011-05-20T08:23:35.640+02:00</sv:value>
+                </sv:property>
+                <sv:property sv:name="jcr:createdBy" sv:type="String">
+                    <sv:value>admin</sv:value>
+                </sv:property>
+                <sv:node sv:name="jcr:content">
+                    <sv:property sv:name="jcr:primaryType" sv:type="Name">
+                        <sv:value>nt:unstructured</sv:value>
+                    </sv:property>
+                    <sv:property sv:name="jcr:data" sv:type="String">
+                        <sv:value>aDEuIENoYXB0ZXIgMSBUaXRsZQoKCiogZm9vCiogYmFyCioqIGZvbzIKKiogZm9vMwoqIGZvbzAKCnx8IGhlYWRlciB8fCBiYXIgfHwKfCBoIHwgaiB8IAoKW0Zvb3wgaHR0cDovL2xpaXAuY2hdCgp7Y29kZX0KaGVsbG8gd29ybGQKe2NvZGV9CgojIGZvbwojIGIKCgpoMi4gU2VjdGlvbiAxLjEgVGl0bGUKCgpTdWJzZWN0aW9uIDEuMS4xIFRpdGxlCn5+fn5+fn5+fn5+fn5+fn5+fn5+fn4KClNlY3Rpb24gMS4yIFRpdGxlCi0tLS0tLS0tLS0tLS0tLS0tCgpDaGFwdGVyIDIgVGl0bGUKPT09PT09PT09PT09PT09Cg==</sv:value>
+                    </sv:property>
+                    <sv:property sv:name="jcr:lastModified" sv:type="Date">
+                        <sv:value>2009-04-27T13:01:07.472+02:00</sv:value>
+                    </sv:property>
+                    <sv:property sv:name="jcr:mimeType" sv:type="String">
+                        <sv:value>text/plain</sv:value>
+                    </sv:property>
+                    <sv:property sv:name="someProperty" sv:type="String">
+                        <sv:value>yo</sv:value>
+                    </sv:property>
+                </sv:node>
+            </sv:node>
+        </sv:node>
+        <sv:node sv:name="dstNode">
+            <sv:property sv:name="jcr:primaryType" sv:type="Name">
+                <sv:value>nt:folder</sv:value>
+            </sv:property>
+            <sv:property sv:name="jcr:created" sv:type="Date">
+                <sv:value>2011-05-20T08:23:35.640+02:00</sv:value>
+            </sv:property>
+            <sv:property sv:name="jcr:createdBy" sv:type="String">
+                <sv:value>admin</sv:value>
+            </sv:property>
+        </sv:node>
     </sv:node>
-  </sv:node>
+    <sv:node sv:name="testWorkspaceCopyOther">
+        <sv:property sv:name="jcr:primaryType" sv:type="Name">
+            <sv:value>nt:unstructured</sv:value>
+        </sv:property>
+    </sv:node>
+    <sv:node sv:name="testCopyProperty">
+        <sv:property sv:name="jcr:primaryType" sv:type="Name">
+            <sv:value>nt:folder</sv:value>
+        </sv:property>
+        <sv:property sv:name="jcr:created" sv:type="Date">
+            <sv:value>2011-05-20T08:23:35.643+02:00</sv:value>
+        </sv:property>
+        <sv:property sv:name="jcr:createdBy" sv:type="String">
+            <sv:value>admin</sv:value>
+        </sv:property>
+        <sv:node sv:name="srcFile">
+            <sv:property sv:name="jcr:primaryType" sv:type="Name">
+                <sv:value>nt:file</sv:value>
+            </sv:property>
+            <sv:property sv:name="jcr:created" sv:type="Date">
+                <sv:value>2011-05-20T08:23:35.643+02:00</sv:value>
+            </sv:property>
+            <sv:property sv:name="jcr:createdBy" sv:type="String">
+                <sv:value>admin</sv:value>
+            </sv:property>
+            <sv:node sv:name="jcr:content">
+                <sv:property sv:name="jcr:primaryType" sv:type="Name">
+                    <sv:value>nt:unstructured</sv:value>
+                </sv:property>
+                <sv:property sv:name="jcr:data" sv:type="String">
+                    <sv:value>aDEuIENoYXB0ZXIgMSBUaXRsZQoKCiogZm9vCiogYmFyCioqIGZvbzIKKiogZm9vMwoqIGZvbzAKCnx8IGhlYWRlciB8fCBiYXIgfHwKfCBoIHwgaiB8IAoKW0Zvb3wgaHR0cDovL2xpaXAuY2hdCgp7Y29kZX0KaGVsbG8gd29ybGQKe2NvZGV9CgojIGZvbwojIGIKCgpoMi4gU2VjdGlvbiAxLjEgVGl0bGUKCgpTdWJzZWN0aW9uIDEuMS4xIFRpdGxlCn5+fn5+fn5+fn5+fn5+fn5+fn5+fn4KClNlY3Rpb24gMS4yIFRpdGxlCi0tLS0tLS0tLS0tLS0tLS0tCgpDaGFwdGVyIDIgVGl0bGUKPT09PT09PT09PT09PT09Cg==</sv:value>
+                </sv:property>
+                <sv:property sv:name="jcr:lastModified" sv:type="Date">
+                    <sv:value>2009-04-27T13:01:07.472+02:00</sv:value>
+                </sv:property>
+                <sv:property sv:name="jcr:mimeType" sv:type="String">
+                    <sv:value>text/plain</sv:value>
+                </sv:property>
+                <sv:property sv:name="someProperty" sv:type="String">
+                    <sv:value>yo</sv:value>
+                </sv:property>
+            </sv:node>
+        </sv:node>
+        <sv:node sv:name="dstFile">
+            <sv:property sv:name="jcr:primaryType" sv:type="Name">
+                <sv:value>nt:file</sv:value>
+            </sv:property>
+            <sv:property sv:name="jcr:created" sv:type="Date">
+                <sv:value>2011-05-20T08:23:35.644+02:00</sv:value>
+            </sv:property>
+            <sv:property sv:name="jcr:createdBy" sv:type="String">
+                <sv:value>admin</sv:value>
+            </sv:property>
+            <sv:node sv:name="jcr:content">
+                <sv:property sv:name="jcr:primaryType" sv:type="Name">
+                    <sv:value>nt:unstructured</sv:value>
+                </sv:property>
+                <sv:property sv:name="jcr:lastModified" sv:type="Date">
+                    <sv:value>2009-04-27T13:01:07.472+02:00</sv:value>
+                </sv:property>
+                <sv:property sv:name="jcr:mimeType" sv:type="String">
+                    <sv:value>text/plain</sv:value>
+                </sv:property>
+            </sv:node>
+        </sv:node>
+    </sv:node>
+    <sv:node sv:name="testCopyInvalidDstPath">
+        <sv:property sv:name="jcr:primaryType" sv:type="Name">
+            <sv:value>nt:unstructured</sv:value>
+        </sv:property>
+        <sv:node sv:name="srcNode">
+            <sv:property sv:name="jcr:primaryType" sv:type="Name">
+                <sv:value>nt:folder</sv:value>
+            </sv:property>
+            <sv:property sv:name="jcr:created" sv:type="Date">
+                <sv:value>2011-05-20T08:23:35.645+02:00</sv:value>
+            </sv:property>
+            <sv:property sv:name="jcr:createdBy" sv:type="String">
+                <sv:value>admin</sv:value>
+            </sv:property>
+        </sv:node>
+        <sv:node sv:name="dstNode">
+            <sv:property sv:name="jcr:primaryType" sv:type="Name">
+                <sv:value>nt:folder</sv:value>
+            </sv:property>
+            <sv:property sv:name="jcr:created" sv:type="Date">
+                <sv:value>2011-05-20T08:23:35.645+02:00</sv:value>
+            </sv:property>
+            <sv:property sv:name="jcr:createdBy" sv:type="String">
+                <sv:value>admin</sv:value>
+            </sv:property>
+        </sv:node>
+    </sv:node>
+    <sv:node sv:name="testCopySrcNotFound">
+        <sv:property sv:name="jcr:primaryType" sv:type="Name">
+            <sv:value>nt:unstructured</sv:value>
+        </sv:property>
+        <sv:node sv:name="dstNode">
+            <sv:property sv:name="jcr:primaryType" sv:type="Name">
+                <sv:value>nt:folder</sv:value>
+            </sv:property>
+            <sv:property sv:name="jcr:created" sv:type="Date">
+                <sv:value>2011-05-20T08:23:35.645+02:00</sv:value>
+            </sv:property>
+            <sv:property sv:name="jcr:createdBy" sv:type="String">
+                <sv:value>admin</sv:value>
+            </sv:property>
+        </sv:node>
+    </sv:node>
+    <sv:node sv:name="testCopyDstParentNotFound">
+        <sv:property sv:name="jcr:primaryType" sv:type="Name">
+            <sv:value>nt:unstructured</sv:value>
+        </sv:property>
+        <sv:node sv:name="srcNode">
+            <sv:property sv:name="jcr:primaryType" sv:type="Name">
+                <sv:value>nt:folder</sv:value>
+            </sv:property>
+            <sv:property sv:name="jcr:created" sv:type="Date">
+                <sv:value>2011-05-20T08:23:35.645+02:00</sv:value>
+            </sv:property>
+            <sv:property sv:name="jcr:createdBy" sv:type="String">
+                <sv:value>admin</sv:value>
+            </sv:property>
+        </sv:node>
+        <sv:node sv:name="dstNode">
+            <sv:property sv:name="jcr:primaryType" sv:type="Name">
+                <sv:value>nt:folder</sv:value>
+            </sv:property>
+            <sv:property sv:name="jcr:created" sv:type="Date">
+                <sv:value>2011-05-20T08:23:35.645+02:00</sv:value>
+            </sv:property>
+            <sv:property sv:name="jcr:createdBy" sv:type="String">
+                <sv:value>admin</sv:value>
+            </sv:property>
+        </sv:node>
+    </sv:node>
+    <sv:node sv:name="testCopyNoUpdateOnCopy">
+        <sv:property sv:name="jcr:primaryType" sv:type="Name">
+            <sv:value>nt:unstructured</sv:value>
+        </sv:property>
+        <sv:node sv:name="srcNode">
+            <sv:property sv:name="jcr:primaryType" sv:type="Name">
+                <sv:value>nt:folder</sv:value>
+            </sv:property>
+            <sv:property sv:name="jcr:created" sv:type="Date">
+                <sv:value>2011-05-20T08:23:35.645+02:00</sv:value>
+            </sv:property>
+            <sv:property sv:name="jcr:createdBy" sv:type="String">
+                <sv:value>admin</sv:value>
+            </sv:property>
+        </sv:node>
+        <sv:node sv:name="dstNode">
+            <sv:property sv:name="jcr:primaryType" sv:type="Name">
+                <sv:value>nt:folder</sv:value>
+            </sv:property>
+            <sv:property sv:name="jcr:created" sv:type="Date">
+                <sv:value>2011-05-20T08:23:35.645+02:00</sv:value>
+            </sv:property>
+            <sv:property sv:name="jcr:createdBy" sv:type="String">
+                <sv:value>admin</sv:value>
+            </sv:property>
+            <sv:node sv:name="srcNode">
+                <sv:property sv:name="jcr:primaryType" sv:type="Name">
+                    <sv:value>nt:folder</sv:value>
+                </sv:property>
+                <sv:property sv:name="jcr:created" sv:type="Date">
+                    <sv:value>2011-05-20T08:23:35.646+02:00</sv:value>
+                </sv:property>
+                <sv:property sv:name="jcr:createdBy" sv:type="String">
+                    <sv:value>admin</sv:value>
+                </sv:property>
+            </sv:node>
+        </sv:node>
+    </sv:node>
+    <sv:node sv:name="testCopyUpdateOnCopy">
+        <sv:property sv:name="jcr:primaryType" sv:type="Name">
+            <sv:value>nt:unstructured</sv:value>
+        </sv:property>
+        <sv:node sv:name="srcNode">
+            <sv:property sv:name="jcr:primaryType" sv:type="Name">
+                <sv:value>nt:folder</sv:value>
+            </sv:property>
+            <sv:property sv:name="jcr:created" sv:type="Date">
+                <sv:value>2011-05-20T08:23:35.646+02:00</sv:value>
+            </sv:property>
+            <sv:property sv:name="jcr:createdBy" sv:type="String">
+                <sv:value>admin</sv:value>
+            </sv:property>
+            <sv:node sv:name="srcFile">
+                <sv:property sv:name="jcr:primaryType" sv:type="Name">
+                    <sv:value>nt:file</sv:value>
+                </sv:property>
+                <sv:property sv:name="jcr:created" sv:type="Date">
+                    <sv:value>2011-05-20T08:23:35.646+02:00</sv:value>
+                </sv:property>
+                <sv:property sv:name="jcr:createdBy" sv:type="String">
+                    <sv:value>admin</sv:value>
+                </sv:property>
+                <sv:node sv:name="jcr:content">
+                    <sv:property sv:name="jcr:primaryType" sv:type="Name">
+                        <sv:value>nt:unstructured</sv:value>
+                    </sv:property>
+                    <sv:property sv:name="jcr:data" sv:type="String">
+                        <sv:value>aDEuIENoYXB0ZXIgMSBUaXRsZQoKCiogZm9vCiogYmFyCioqIGZvbzIKKiogZm9vMwoqIGZvbzAKCnx8IGhlYWRlciB8fCBiYXIgfHwKfCBoIHwgaiB8IAoKW0Zvb3wgaHR0cDovL2xpaXAuY2hdCgp7Y29kZX0KaGVsbG8gd29ybGQKe2NvZGV9CgojIGZvbwojIGIKCgpoMi4gU2VjdGlvbiAxLjEgVGl0bGUKCgpTdWJzZWN0aW9uIDEuMS4xIFRpdGxlCn5+fn5+fn5+fn5+fn5+fn5+fn5+fn4KClNlY3Rpb24gMS4yIFRpdGxlCi0tLS0tLS0tLS0tLS0tLS0tCgpDaGFwdGVyIDIgVGl0bGUKPT09PT09PT09PT09PT09Cg==</sv:value>
+                    </sv:property>
+                    <sv:property sv:name="jcr:lastModified" sv:type="Date">
+                        <sv:value>2009-04-27T13:01:07.472+02:00</sv:value>
+                    </sv:property>
+                    <sv:property sv:name="jcr:mimeType" sv:type="String">
+                        <sv:value>text/plain</sv:value>
+                    </sv:property>
+                </sv:node>
+            </sv:node>
+            <sv:node sv:name="updateFile">
+                <sv:property sv:name="jcr:primaryType" sv:type="Name">
+                    <sv:value>nt:file</sv:value>
+                </sv:property>
+                <sv:property sv:name="jcr:created" sv:type="Date">
+                    <sv:value>2011-05-20T08:23:35.646+02:00</sv:value>
+                </sv:property>
+                <sv:property sv:name="jcr:createdBy" sv:type="String">
+                    <sv:value>admin</sv:value>
+                </sv:property>
+                <sv:node sv:name="jcr:content">
+                    <sv:property sv:name="jcr:primaryType" sv:type="Name">
+                        <sv:value>nt:unstructured</sv:value>
+                    </sv:property>
+                    <sv:property sv:name="jcr:data" sv:type="String">
+                        <sv:value>123</sv:value>
+                    </sv:property>
+                    <sv:property sv:name="jcr:mimeType" sv:type="String">
+                        <sv:value>text/plain</sv:value>
+                    </sv:property>
+                </sv:node>
+            </sv:node>
+        </sv:node>
+        <sv:node sv:name="dstNode">
+            <sv:property sv:name="jcr:primaryType" sv:type="Name">
+                <sv:value>nt:folder</sv:value>
+            </sv:property>
+            <sv:property sv:name="jcr:created" sv:type="Date">
+                <sv:value>2011-05-20T08:23:35.647+02:00</sv:value>
+            </sv:property>
+            <sv:property sv:name="jcr:createdBy" sv:type="String">
+                <sv:value>admin</sv:value>
+            </sv:property>
+            <sv:node sv:name="srcNode">
+                <sv:property sv:name="jcr:primaryType" sv:type="Name">
+                    <sv:value>nt:folder</sv:value>
+                </sv:property>
+                <sv:property sv:name="jcr:created" sv:type="Date">
+                    <sv:value>2011-05-20T08:23:35.647+02:00</sv:value>
+                </sv:property>
+                <sv:property sv:name="jcr:createdBy" sv:type="String">
+                    <sv:value>admin</sv:value>
+                </sv:property>
+                <sv:node sv:name="updateFile">
+                    <sv:property sv:name="jcr:primaryType" sv:type="Name">
+                        <sv:value>nt:file</sv:value>
+                    </sv:property>
+                    <sv:property sv:name="jcr:created" sv:type="Date">
+                        <sv:value>2011-05-20T08:23:35.647+02:00</sv:value>
+                    </sv:property>
+                    <sv:property sv:name="jcr:createdBy" sv:type="String">
+                        <sv:value>admin</sv:value>
+                    </sv:property>
+                    <sv:node sv:name="jcr:content">
+                        <sv:property sv:name="jcr:primaryType" sv:type="Name">
+                            <sv:value>nt:unstructured</sv:value>
+                        </sv:property>
+                        <sv:property sv:name="jcr:data" sv:type="String">
+                            <sv:value>1</sv:value>
+                        </sv:property>
+                        <sv:property sv:name="jcr:mimeType" sv:type="String">
+                            <sv:value>text/plain</sv:value>
+                        </sv:property>
+                    </sv:node>
+                </sv:node>
+            </sv:node>
+        </sv:node>
+    </sv:node>
 </sv:node>

--- a/tests/10_Writing/CopyMethodsTest.php
+++ b/tests/10_Writing/CopyMethodsTest.php
@@ -84,9 +84,9 @@ class CopyMethodsTest extends \PHPCR\Test\BaseCase
         $this->assertNotEquals($snode->getIdentifier(), $dnode->getIdentifier());
 
         $homeNode = $dnode->getNode('home');
-        $block1Ref = $homeNode->getProperty('block_1')->getValue()->getIdentifier();
-        $block2Ref = $homeNode->getProperty('block_2')->getValue()->getIdentifier();
-        $block3Ref = $homeNode->getProperty('block_2')->getValue()->getIdentifier();
+        $block1Ref = $homeNode->getProperty('block_1_ref')->getValue()->getIdentifier();
+        $block2Ref = $homeNode->getProperty('block_2_ref')->getValue()->getIdentifier();
+        $block3Ref = $homeNode->getProperty('block_2_ref')->getValue()->getIdentifier();
 
         $externalRef = $homeNode->getProperty('external_reference')->getValue()->getIdentifier();
 

--- a/tests/10_Writing/CopyMethodsTest.php
+++ b/tests/10_Writing/CopyMethodsTest.php
@@ -71,6 +71,38 @@ class CopyMethodsTest extends \PHPCR\Test\BaseCase
         $this->assertNotEquals($sfile->getPropertyValue('jcr:data'), $dfile->getPropertyValue('jcr:data'));
     }
 
+    public function testWorkspaceCopyReference()
+    {
+        $src = '/tests_write_manipulation_copy/testWorkspaceCopy/referencedNodeSet';
+        $dst = '/tests_write_manipulation_copy/testWorkspaceCopy/dstNode/copiedReferencedSet';
+
+        $this->ws->copy($src, $dst);
+
+        $snode = $this->session->getNode($src);
+        $dnode = $this->session->getNode($dst);
+
+        $this->assertNotEquals($snode->getIdentifier(), $dnode->getIdentifier());
+
+        $homeNode = $dnode->getNode('home');
+        $block1Ref = $homeNode->getProperty('block_1')->getValue()->getIdentifier();
+        $block2Ref = $homeNode->getProperty('block_2')->getValue()->getIdentifier();
+        $block3Ref = $homeNode->getProperty('block_2')->getValue()->getIdentifier();
+
+        $externalRef = $homeNode->getProperty('external_reference')->getValue()->getIdentifier();
+
+        $this->assertEquals('842e61c0-09ab-42a9-87c0-308ccc90e6f6', $externalRef);
+
+        $block1 = $homeNode->getNode('block_1');
+        $this->assertEquals($block1->getIdentifier(), $block1Ref);
+
+        $block2 = $block1->getNode('block_2');
+        $this->assertEquals($block2->getIdentifier(), $block2Ref);
+
+        // weak reference
+        $block3 = $block1->getNode('block_3');
+        $this->assertEquals($block2->getIdentifier(), $block2Ref);
+    }
+
     public function testWorkspaceCopyOther()
     {
         self::$staticSharedFixture['ie']->import('general/additionalWorkspace', 'additionalWorkspace');


### PR DESCRIPTION
Ensure that references within a copied set remain consistent.

i.e. if a node with a set references another node within the set, then the reference in the new set should not reference the old set.