### PR TITLE
added test for deleting a node with a reference from a multiple property field

### DIFF
--- a/fixtures/10_Writing/delete.xml
+++ b/fixtures/10_Writing/delete.xml
@@ -209,6 +209,27 @@
     </sv:node>
   </sv:node>
 
+  <sv:node sv:name="testDeletePreviouslyReferencedNodeInMultipleProperty">
+    <sv:property sv:name="jcr:primaryType" sv:type="Name">
+      <sv:value>nt:unstructured</sv:value>
+    </sv:property>
+    <sv:property sv:name="reference" sv:type="Reference" sv:multiple="true">
+      <sv:value>7aa10003-0cba-4820-a3e4-f9b1ae8126de</sv:value>
+    </sv:property>
+
+    <sv:node sv:name="idExample">
+      <sv:property sv:name="jcr:primaryType" sv:type="Name">
+        <sv:value>nt:unstructured</sv:value>
+      </sv:property>
+      <sv:property sv:name="jcr:mixinTypes" sv:type="Name">
+        <sv:value>mix:referenceable</sv:value>
+      </sv:property>
+      <sv:property sv:name="jcr:uuid" sv:type="String">
+        <sv:value>7aa10003-0cba-4820-a3e4-f9b1ae8126de</sv:value>
+      </sv:property>
+    </sv:node>
+  </sv:node>
+
   <sv:node sv:name="testDeleteWeakReferencedNode">
     <sv:property sv:name="jcr:primaryType" sv:type="Name">
       <sv:value>nt:unstructured</sv:value>

--- a/tests/Writing/DeleteMethodsTest.php
+++ b/tests/Writing/DeleteMethodsTest.php
@@ -451,6 +451,28 @@ class DeleteMethodsTest extends \PHPCR\Test\BaseCase
     }
 
     /**
+     * however, if the reference is first deleted, it must be possible to
+     * delete the node, also if it is an multiple reference property
+     */
+    public function testDeletePreviouslyReferencedNodeInMultipleProperty()
+    {
+        //relies on the base class setup trick to have the node populated from the fixtures
+        $this->assertInstanceOf('PHPCR\NodeInterface', $this->node);
+
+        // 2) Get the referencing property and delete it
+        $sourceprop = $this->node->getProperty('reference');
+        $sourceprop->setValue(array());
+
+        // 4) Load the previously referenced node and remove it
+        $destnode = $this->node->getNode('idExample');
+
+        $destnode->remove();
+        $this->saveAndRenewSession();
+
+        $this->assertFalse($this->node->hasNode($this->getName()));
+    }
+
+    /**
      * it must be possible to delete a weakly referenced node.
      */
     public function testDeleteWeakReferencedNode()


### PR DESCRIPTION
This test is currently failing for jackalope-doctrine-dbal.