### PR TITLE
more tests for multivalue binary operations

### DIFF
--- a/fixtures/10_Writing/copy.xml
+++ b/fixtures/10_Writing/copy.xml
@@ -493,11 +493,29 @@
             <sv:property sv:name="jcr:primaryType" sv:type="Name">
                 <sv:value>nt:unstructured</sv:value>
             </sv:property>
-            <sv:node sv:name="data.bin">
+            <sv:node sv:name="single">
                 <sv:property sv:name="jcr:primaryType" sv:type="Name">
                     <sv:value>nt:unstructured</sv:value>
                 </sv:property>
                 <sv:property sv:name="jcr:data" sv:type="Binary"><sv:value>RnVzY2UgZmVybWVudHVtLiBBbGlxdWFtIGxvYm9ydGlzLiBNYXVyaXMgdHVycGlzIG51bmMsIGJsYW5kaXQgZXQsIHZvbHV0cGF0IG1vbGVzdGllLCBwb3J0YSB1dCwgbGlndWxhLiBQZWxsZW50ZXNxdWUgYXVjdG9yIG5lcXVlIG5lYyB1cm5hLiBQcm9pbiBtYWduYS4gQ3VyYWJpdHVyIHVsbGFtY29ycGVyIHVsdHJpY2llcyBuaXNpLiBQcmFlc2VudCBjb25ndWUgZXJhdCBhdCBtYXNzYS4gTmFtIGFkaXBpc2NpbmcuIE51bGxhIHBvcnRhIGRvbG9yLiBGdXNjZSBjb21tb2RvIGFsaXF1YW0gYXJjdS4=</sv:value>
+                </sv:property>
+            </sv:node>
+        </sv:node>
+    </sv:node>
+
+    <sv:node sv:name="testCopyChildrenBinaryDataMultivalue">
+        <sv:property sv:name="jcr:primaryType" sv:type="Name">
+            <sv:value>nt:unstructured</sv:value>
+        </sv:property>
+        <sv:node sv:name="srcNode">
+            <sv:property sv:name="jcr:primaryType" sv:type="Name">
+                <sv:value>nt:unstructured</sv:value>
+            </sv:property>
+            <sv:node sv:name="multiple">
+                <sv:property sv:name="jcr:primaryType" sv:type="Name">
+                    <sv:value>nt:unstructured</sv:value>
+                </sv:property>
+                <sv:property sv:name="jcr:data" sv:type="Binary" sv:multiple="true"><sv:value>RnVzY2UgZmVybWVudHVtLiBBbGlxdWFtIGxvYm9ydGlzLiBNYXVyaXMgdHVycGlzIG51bmMsIGJsYW5kaXQgZXQsIHZvbHV0cGF0IG1vbGVzdGllLCBwb3J0YSB1dCwgbGlndWxhLiBQZWxsZW50ZXNxdWUgYXVjdG9yIG5lcXVlIG5lYyB1cm5hLiBQcm9pbiBtYWduYS4gQ3VyYWJpdHVyIHVsbGFtY29ycGVyIHVsdHJpY2llcyBuaXNpLiBQcmFlc2VudCBjb25ndWUgZXJhdCBhdCBtYXNzYS4gTmFtIGFkaXBpc2NpbmcuIE51bGxhIHBvcnRhIGRvbG9yLiBGdXNjZSBjb21tb2RvIGFsaXF1YW0gYXJjdS4=</sv:value><sv:value>RnVzY2UgZmVybWVudHVtLiBBbGlxdWFtIGxvYm9ydGlzLiBNYXVyaXMgdHVycGlzIG51bmMsIGJsYW5kaXQgZXQsIHZvbHV0cGF0IG1vbGVzdGllLCBwb3J0YSB1dCwgbGlndWxhLiBQZWxsZW50ZXNxdWUgYXVjdG9yIG5lcXVlIG5lYyB1cm5hLiBQcm9pbiBtYWduYS4gQ3VyYWJpdHVyIHVsbGFtY29ycGVyIHVsdHJpY2llcyBuaXNpLiBQcmFlc2VudCBjb25ndWUgZXJhdCBhdCBtYXNzYS4gTmFtIGFkaXBpc2NpbmcuIE51bGxhIHBvcnRhIGRvbG9yLiBGdXNjZSBjb21tb2RvIGFsaXF1YW0gYXJjdS4=</sv:value>
                 </sv:property>
             </sv:node>
         </sv:node>

--- a/fixtures/general/base.xml
+++ b/fixtures/general/base.xml
@@ -53,6 +53,11 @@
                 <sv:value>aDEuIENoYXB0ZXIgMSBUaXRsZQoKKiBmb28KKiBiYXIKKiogZm9vMgoqKiBmb28zCiogZm9vMAoKfHwgaGVhZGVyIHx8IGJhciB8fAp8IGggfCBqIHwKCntjb2RlfQpoZWxsbyB3b3JsZAp7Y29kZX0KCiMgZm9vCg==</sv:value>
                 <sv:value>aDEuIENoYXB0ZXIgMSBUaXRsZQoKKiBmb28KKiBiYXIKKiogZm9vMgoqKiBmb28zCiogZm9vMAoKfHwgaGVhZGVyIHx8IGJhciB8fAp8IGggfCBqIHwKCntjb2RlfQpoZWxsbyB3b3JsZAp7Y29kZX0KCiMgZm9vCg==</sv:value>
             </sv:property>
+            <sv:property sv:name="single_multidata" sv:type="Binary" sv:multiple="true">
+                <sv:value></sv:value>
+            </sv:property>
+            <sv:property sv:name="empty_multidata" sv:type="Binary" sv:multiple="true">
+            </sv:property>
             <sv:property sv:name="jcr:lastModified" sv:type="Date">
                 <sv:value>2009-04-27T13:01:07.472+02:00</sv:value>
             </sv:property>

--- a/tests/Reading/BinaryReadMethodsTest.php
+++ b/tests/Reading/BinaryReadMethodsTest.php
@@ -146,4 +146,33 @@ hello world
         $this->assertInternalType('string', $value);
         $this->assertEquals($this->decodedstring, $value);
     }
+
+    /**
+     * Verifies that we still can read empty data from multivalue binary properties
+     * @group multitest
+     */
+    public function testReadEmptyBinaryMultivalue()
+    {
+        $node = $this->session->getRootNode()->getNode('tests_general_base/index.txt/jcr:content');
+        $empty = $node->getProperty('empty_multidata');
+        $this->assertEquals(\PHPCR\PropertyType::BINARY, $empty->getType());
+        $emptyValue = $empty->getBinary();
+        $this->assertTrue(is_array($emptyValue));
+        $this->assertTrue(count($emptyValue) === 0);
+    }
+
+    /**
+     * Verifies that we still can read empty data from multivalue binary properties
+     */
+    public function testReadSingleBinaryMultivalue()
+    {
+        $node = $this->session->getRootNode()->getNode('tests_general_base/index.txt/jcr:content');
+        $single = $node->getProperty('single_multidata');
+        $this->assertEquals(\PHPCR\PropertyType::BINARY, $single->getType());
+        $singleValue = $single->getBinary();
+        $this->assertTrue(is_array($singleValue));
+        $this->assertTrue(is_resource($singleValue[0]));
+        $contents = stream_get_contents($singleValue[0]);
+        $this->assertEquals('', $contents);
+    }
 }

--- a/tests/Writing/CopyMethodsTest.php
+++ b/tests/Writing/CopyMethodsTest.php
@@ -250,21 +250,54 @@ class CopyMethodsTest extends \PHPCR\Test\BaseCase
 
         $this->ws->copy($src, $dst);
         $this->session->refresh(true);
-        $srcChild = $this->session->getNode($src.'/data.bin');
-        $dstChild = $this->session->getNode($dst.'/data.bin');
 
-        $srcProp = $srcChild->getProperty('jcr:data');
-        $dstProp = $dstChild->getProperty('jcr:data');
+        //Single value
+        $srcProp = $this->session->getNode($src . '/single')->getProperty('jcr:data');
+        $dstProp = $this->session->getNode($dst . '/single')->getProperty('jcr:data');
 
         $this->assertEquals(\PHPCR\PropertyType::BINARY, $srcProp->getType());
         $this->assertEquals(\PHPCR\PropertyType::BINARY, $dstProp->getType());
 
-        $srcBin = $srcProp->getBinary();
-        $dstBin = $dstProp->getBinary();
+        $srcVal = $srcProp->getBinary();
+        $dstVal = $dstProp->getBinary();
 
-        $this->assertTrue(is_resource($srcBin), 'Failed to get src binary stream');
-        $this->assertTrue(is_resource($dstBin), 'Failed to get dst binary stream');
+        $this->assertTrue(is_resource($srcVal), 'Failed to get src binary stream');
+        $this->assertTrue(is_resource($dstVal), 'Failed to get dst binary stream');
 
-        $this->assertEquals(stream_get_contents($srcBin), stream_get_contents($dstBin));
+        $this->assertEquals(stream_get_contents($srcVal), stream_get_contents($dstVal));
+    }
+
+    /**
+     * Verifies that transport::copy actually copies binary data of children nodes
+     * Multivalue test
+     */
+    public function testCopyChildrenBinaryDataMultivalue()
+    {
+        $src = '/tests_write_manipulation_copy/testCopyChildrenBinaryDataMultivalue/srcNode';
+        $dst = '/tests_write_manipulation_copy/testCopyChildrenBinaryDataMultivalue/dstNode';
+
+        $this->ws->copy($src, $dst);
+        $this->session->refresh(true);
+
+        //Multivalue
+        $srcProp = $this->session->getNode($src.'/multiple')->getProperty('jcr:data');
+        $dstProp = $this->session->getNode($dst.'/multiple')->getProperty('jcr:data');
+
+        $this->assertEquals(\PHPCR\PropertyType::BINARY, $srcProp->getType());
+        $this->assertEquals(\PHPCR\PropertyType::BINARY, $dstProp->getType());
+
+        $srcVal = $srcProp->getValue();
+        $dstVal = $dstProp->getValue();
+
+        $this->assertTrue(is_array($srcVal), 'Failed to get src value');
+        $this->assertTrue(is_array($dstVal), 'Failed to get dst value');
+
+        $this->assertTrue(is_resource($srcVal[0]));
+        $this->assertTrue(is_resource($srcVal[1]));
+        $this->assertTrue(is_resource($dstVal[0]));
+        $this->assertTrue(is_resource($dstVal[1]));
+
+        $this->assertEquals(stream_get_contents($srcVal[0]), stream_get_contents($dstVal[0]));
+        $this->assertEquals(stream_get_contents($srcVal[1]), stream_get_contents($dstVal[1]));
     }
 }


### PR DESCRIPTION
Added a test for multivalue binary copy.
Added test to check unusual binary properties behavior: one for multivalue property with no values in it and another for multivalue property with a single value in it - it fails with error.