### PR TITLE
added test for restoring after failed referential integrity checks

### DIFF
--- a/fixtures/10_Writing/delete.xml
+++ b/fixtures/10_Writing/delete.xml
@@ -188,6 +188,27 @@
     </sv:node>
   </sv:node>
 
+  <sv:node sv:name="testDeleteReferencedNodeWithClearingSession">
+    <sv:property sv:name="jcr:primaryType" sv:type="Name">
+        <sv:value>nt:unstructured</sv:value>
+    </sv:property>
+    <sv:property sv:name="reference" sv:type="Reference">
+        <sv:value>842e61c0-09ab-42a9-87c0-308ccc91e6f4</sv:value>
+    </sv:property>
+
+    <sv:node sv:name="idExample">
+        <sv:property sv:name="jcr:primaryType" sv:type="Name">
+            <sv:value>nt:unstructured</sv:value>
+        </sv:property>
+        <sv:property sv:name="jcr:mixinTypes" sv:type="Name">
+            <sv:value>mix:referenceable</sv:value>
+        </sv:property>
+        <sv:property sv:name="jcr:uuid" sv:type="String">
+            <sv:value>842e61c0-09ab-42a9-87c0-308ccc91e6f4</sv:value>
+        </sv:property>
+    </sv:node>
+  </sv:node>
+
   <sv:node sv:name="testDeletePreviouslyReferencedNode">
     <sv:property sv:name="jcr:primaryType" sv:type="Name">
       <sv:value>nt:unstructured</sv:value>

--- a/tests/Writing/DeleteMethodsTest.php
+++ b/tests/Writing/DeleteMethodsTest.php
@@ -12,6 +12,7 @@
 namespace PHPCR\Tests\Writing;
 
 use PHPCR\ItemNotFoundException;
+use PHPCR\ReferentialIntegrityException;
 
 /**
  * Covering jcr-2.8.3 spec $10.9.
@@ -426,6 +427,25 @@ class DeleteMethodsTest extends \PHPCR\Test\BaseCase
         $destnode = $this->node->getNode('idExample');
         $destnode->remove();
         $this->session->save();
+    }
+
+    /**
+     * The session should be able to refresh after some referential integrity has failed.
+     */
+    public function testDeleteReferencedNodeWithClearingSession()
+    {
+        $this->assertInstanceOf('PHPCR\NodeInterface', $this->node);
+
+        try {
+            $destnode = $this->node->getNode('idExample');
+            $destnode->remove();
+            $this->session->save();
+        } catch (ReferentialIntegrityException $e) {
+        }
+
+        $this->session->refresh(false);
+
+        $this->assertInstanceOf('PHPCR\NodeInterface', $this->node->getNode('idExample'));
     }
 
     /**


### PR DESCRIPTION
I have encountered that it is not possible to restore the `Session` after calling `Session::save()` and getting a `ReferentialIntegrityException` in Jackalope, because of the line https://github.com/jackalope/jackalope/blob/master/src/Jackalope/ObjectManager.php#L1110.

The `getIdentifier` method fails, because the `jcr:uuid` property of the node is still marked as deleted, and throws an exception because of that.

Would try to tackle that problem on my own, if you could give me an idea where the state of this property should be rollbacked. /cc @lsmith77 @dbu 
