### PR TITLE
Added test for removing node in other session and refreshing

### DIFF
--- a/fixtures/10_Writing/combinedmanipulations.xml
+++ b/fixtures/10_Writing/combinedmanipulations.xml
@@ -263,6 +263,24 @@
     </sv:node>
   </sv:node>
 
+  <sv:node sv:name="testRemoveNewNodeInOtherSessionDiscardChanges">
+    <sv:property sv:name="jcr:primaryType" sv:type="Name">
+      <sv:value>nt:unstructured</sv:value>
+    </sv:property>
+  </sv:node>
+
+  <sv:node sv:name="testRemoveNewNodeInOtherSessionKeepChanges">
+    <sv:property sv:name="jcr:primaryType" sv:type="Name">
+      <sv:value>nt:unstructured</sv:value>
+    </sv:property>
+  </sv:node>
+
+  <sv:node sv:name="testRemoveNodeInOtherSessionKeepChangeg">
+    <sv:property sv:name="jcr:primaryType" sv:type="Name">
+      <sv:value>nt:unstructured</sv:value>
+    </sv:property>
+  </sv:node>
+
   <sv:node sv:name="testMoveSessionRefresh">
     <sv:property sv:name="jcr:primaryType" sv:type="Name">
       <sv:value>nt:unstructured</sv:value>


### PR DESCRIPTION
Uncovers issue raised in https://github.com/jackalope/jackalope-doctrine-dbal/pull/323
