### PR TITLE
Test comparing multiple LONG property in query

### DIFF
--- a/fixtures/general/base.xml
+++ b/fixtures/general/base.xml
@@ -360,6 +360,12 @@
                 <sv:value>2</sv:value>
             </sv:property>
 
+            <sv:property sv:name="longNumberToCompareMulti" sv:type="Long" sv:multiple="true">
+                <sv:value>4</sv:value>
+                <sv:value>2</sv:value>
+                <sv:value>8</sv:value>
+            </sv:property>
+
             <sv:property sv:name="stringToCompare" sv:type="String">
                 <sv:value>2</sv:value>
             </sv:property>

--- a/tests/Query/QueryResultsTest.php
+++ b/tests/Query/QueryResultsTest.php
@@ -172,6 +172,30 @@ class QueryResultsTest extends QueryBaseCase
         $this->assertEquals(10, $rows[0]->getValue('data.longNumberToCompare'));
     }
 
+    public function testCompareNumberFieldsMulti()
+    {
+        $query = $this->sharedFixture['qm']->createQuery('
+            SELECT data.longNumberToCompareMulti
+            FROM [nt:unstructured] AS data
+            WHERE data.longNumberToCompareMulti = 2
+              AND ISDESCENDANTNODE([/tests_general_base])
+            ',
+            \PHPCR\Query\QueryInterface::JCR_SQL2
+        );
+        $result = $query->execute();
+
+        $rows = array();
+        foreach ($result->getRows() as $row) {
+            $rows[] = $row;
+        }
+
+        $this->assertCount(1, $rows);
+        
+        // returning a string value is, perhaps suprisingly, the correct behavior.
+        $this->assertEquals('4 2 8', $rows[0]->getValue('data.longNumberToCompareMulti'));
+    }
+
+
     public function testCompareStringFields()
     {
         $query = $this->sharedFixture['qm']->createQuery(


### PR DESCRIPTION
Test for `=` comparing a multi-value LONG property in a query.

See Jackalope DBAL fix for this issue: https://github.com/jackalope/jackalope-doctrine-dbal/pull/327