### PR TITLE
reproduce encoding bug with ischildnode query paths

### DIFF
--- a/fixtures/06_Query/characters.xml
+++ b/fixtures/06_Query/characters.xml
@@ -65,4 +65,23 @@
             </sv:node>
         </sv:node>
     </sv:node>
+
+    <sv:node sv:name="test-2e">
+        <sv:property sv:name="jcr:primaryType" sv:type="Name">
+            <sv:value>nt:unstructured</sv:value>
+        </sv:property>
+
+        <sv:node sv:name="child">
+            <sv:property sv:name="jcr:primaryType" sv:type="Name">
+                <sv:value>nt:unstructured</sv:value>
+            </sv:property>
+
+            <sv:property sv:name="jcr:mixinTypes" sv:type="Name">
+                <sv:value>mix:referenceable</sv:value>
+            </sv:property>
+            <sv:property sv:name="jcr:uuid" sv:type="String">
+                <sv:value>123e61c0-09ab-42a9-87c0-123ccc90e6f4</sv:value>
+            </sv:property>
+        </sv:node>
+    </sv:node>
 </sv:node>

--- a/tests/Query/CharacterTest.php
+++ b/tests/Query/CharacterTest.php
@@ -138,4 +138,22 @@ class CharacterTest extends \PHPCR\Test\BaseCase
         $this->assertCount(1, $rows);
         $this->assertEquals('foo & bar&baz', $rows->current()->getValue('ampersand'));
     }
+
+    public function testNodeNameWithMinus()
+    {
+        /** @var QueryManagerInterface $queryManager */
+        $queryManager = $this->sharedFixture['qm'];
+        $query = $queryManager->createQuery('
+            SELECT node.[jcr:uuid] AS uuid
+            FROM [nt:unstructured] AS node
+            WHERE ISCHILDNODE(node, [/tests_query_encoding/test-2e])',
+            QueryInterface::JCR_SQL2
+        );
+
+        $result = $query->execute();
+
+        $rows = $result->getRows();
+        $this->assertCount(1, $rows);
+        $this->assertEquals('PHPCR\Query\QueryInterface', $rows->current()->getValue('class'));
+    }
 }


### PR DESCRIPTION
Reproduce the bug described in https://github.com/jackalope/jackalope/issues/313

It looks a lot like a jackrabbit bug - the same error happens when using the JavaDavexClient to query within jackrabbit.
