### PR TITLE
Added test for preserving child node order on copy

### DIFF
--- a/fixtures/10_Writing/copy.xml
+++ b/fixtures/10_Writing/copy.xml
@@ -523,4 +523,36 @@
             </sv:node>
         </sv:node>
     </sv:node>
+
+    <sv:node sv:name="testCopyPreserveChildOrder">
+        <sv:property sv:name="jcr:primaryType" sv:type="Name">
+            <sv:value>nt:unstructured</sv:value>
+        </sv:property>
+
+        <sv:node sv:name="srcNode">
+            <sv:property sv:name="jcr:primaryType" sv:type="Name">
+                <sv:value>nt:unstructured</sv:value>
+            </sv:property>
+            <sv:node sv:name="one">
+                <sv:property sv:name="jcr:primaryType" sv:type="Name">
+                    <sv:value>nt:unstructured</sv:value>
+                </sv:property>
+            </sv:node>
+            <sv:node sv:name="two">
+                <sv:property sv:name="jcr:primaryType" sv:type="Name">
+                    <sv:value>nt:unstructured</sv:value>
+                </sv:property>
+            </sv:node>
+            <sv:node sv:name="three">
+                <sv:property sv:name="jcr:primaryType" sv:type="Name">
+                    <sv:value>nt:unstructured</sv:value>
+                </sv:property>
+            </sv:node>
+        </sv:node>
+        <sv:node sv:name="dstNode">
+            <sv:property sv:name="jcr:primaryType" sv:type="Name">
+                <sv:value>nt:unstructured</sv:value>
+            </sv:property>
+        </sv:node>
+    </sv:node>
 </sv:node>

--- a/tests/Writing/CopyMethodsTest.php
+++ b/tests/Writing/CopyMethodsTest.php
@@ -79,6 +79,24 @@ class CopyMethodsTest extends \PHPCR\Test\BaseCase
         $this->assertNotEquals($sfile->getPropertyValue('jcr:data'), $dfile->getPropertyValue('jcr:data'));
     }
 
+    public function testCopyPreserveChildOrder()
+    {
+        $expected = [ 'three', 'one', 'two' ];
+
+        $src = '/tests_write_manipulation_copy/testCopyPreserveChildOrder/srcNode';
+        $dst = '/tests_write_manipulation_copy/testCopyPreserveChildOrder/dstNode/srcNode';
+
+        $node = $this->session->getNode($src);
+        $node->orderBefore('three', 'one');
+        $this->session->save();
+        $this->assertEquals($expected, iterator_to_array($node->getNodeNames()));
+
+        $this->ws->copy($src, $dst);
+
+        $node = $this->session->getNode($dst);
+        $this->assertEquals($expected, iterator_to_array($node->getNodeNames()));
+    }
+
     public function testWorkspaceCopyReference()
     {
         $src = '/tests_write_manipulation_copy/testWorkspaceCopy/referencedNodeSet';


### PR DESCRIPTION
Test for preserving child order on copy, see https://github.com/jackalope/jackalope-doctrine-dbal/pull/333