### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/inc/BaseCase.php
+++ b/inc/BaseCase.php
@@ -19,12 +19,12 @@ use PHPCR\SessionInterface;
 use PHPCR\NodeInterface;
 use DateTime;
 use PHPUnit_Framework_SkippedTestSuiteError;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Base class for all phpcr api tests.
  */
-abstract class BaseCase extends PHPUnit_Framework_TestCase
+abstract class BaseCase extends TestCase
 {
     /**
      * Describes the path to the node for this test, used with writing tests.


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).