### PR TITLE
Refactoring tests

### DIFF
--- a/tests/Locking/LockManagerTest.php
+++ b/tests/Locking/LockManagerTest.php
@@ -137,7 +137,7 @@ class LockManagerTest extends BaseCase
         sleep(2);
         $this->assertFalse($this->lm->isLocked('/lockable-expire'));
         $this->assertFalse($lock->isLive());
-        $this->assertTrue($lock->getSecondsRemaining() < 0);
+        $this->assertLessThan(0, $lock->getSecondsRemaining());
     }
 
     /**

--- a/tests/NodeTypeDiscovery/NodeDefinitionTest.php
+++ b/tests/NodeTypeDiscovery/NodeDefinitionTest.php
@@ -108,24 +108,24 @@ class NodeDefinitionTest extends BaseCase
     {
         $names = $this->content->getRequiredPrimaryTypeNames();
         $this->assertInternalType('array', $names);
-        $this->assertTrue(1, count($names));
+        $this->assertCount(1, $names);
         $this->assertEquals('nt:base', $names[0]);
 
         $names = $this->hierarchyNodeDef->getRequiredPrimaryTypeNames();
         $this->assertInternalType('array', $names);
-        $this->assertTrue(1, count($names));
+        $this->assertCount(1, $names);
         $this->assertEquals('nt:hierarchyNode', $names[0]);
     }
     public function getRequiredPrimaryTypes()
     {
         $types = $this->content->getRequiredPrimaryTypeNames();
         $this->assertInternalType('array', $types);
-        $this->assertTrue(1, count($types));
+        $this->assertCount(1, $types);
         $this->assertEquals(self::$base, $types[0]);
 
         $types = $this->hierarchyNodeDef->getRequiredPrimaryTypeNames();
         $this->assertInternalType('array', $types);
-        $this->assertTrue(1, count($types));
+        $this->assertCount(1, $types);
         $this->assertEquals(self::$hierarchyNodeType, $types[0]);
     }
 

--- a/tests/Observation/ObservationManagerTest.php
+++ b/tests/Observation/ObservationManagerTest.php
@@ -242,7 +242,7 @@ class ObservationManagerTest extends BaseCase
             $journal->next();
 
             // Notice the assertion is slightly different from the one in testFilterOnPathNoDeep
-            $this->assertTrue(substr($event->getPath(), 0, strlen($this->nodePath.'/child')) === $this->nodePath.'/child');
+            $this->assertSame(substr($event->getPath(), 0, strlen($this->nodePath.'/child')), $this->nodePath.'/child');
         }
     }
 

--- a/tests/PhpcrUtils/CndParserTest.php
+++ b/tests/PhpcrUtils/CndParserTest.php
@@ -157,10 +157,10 @@ EOT;
     {
         $res = $this->cndParser->parseFile(__DIR__.'/resources/cnd/no-stop-at-eof.cnd');
 
-        $this->assertTrue(isset($res['namespaces']));
+        $this->assertArrayHasKey('namespaces', $res);
         $this->assertEquals(['phpcr' => 'http://www.doctrine-project.org/projects/phpcr_odm'], $res['namespaces']);
 
-        $this->assertTrue(isset($res['nodeTypes']));
+        $this->assertArrayHasKey('nodeTypes', $res);
     }
 
     public function testBigFile()
@@ -169,10 +169,10 @@ EOT;
         $res = $this->cndParser->parseFile(__DIR__.'/resources/cnd/jackrabbit_nodetypes.cnd');
 
         // some random sanity checks
-        $this->assertTrue(isset($res['nodeTypes']));
+        $this->assertArrayHasKey('nodeTypes', $res);
 
         $def = $res['nodeTypes'];
-        $this->assertTrue(isset($def['nt:file']));
+        $this->assertArrayHasKey('nt:file', $def);
         /** @var $parsed NodeTypeDefinitionInterface */
         $parsed = $def['nt:file'];
         $this->assertEquals('nt:file', $parsed->getName());
@@ -190,10 +190,10 @@ EOT;
      */
     protected function assertExampleCnd($res)
     {
-        $this->assertTrue(isset($res['namespaces']));
+        $this->assertArrayHasKey('namespaces', $res);
         $this->assertEquals(['ns' => 'http://namespace.com/ns'], $res['namespaces']);
 
-        $this->assertTrue(isset($res['nodeTypes']));
+        $this->assertArrayHasKey('nodeTypes', $res);
         // get first node type
         reset($res['nodeTypes']);
         /** @var $def NodeTypeDefinitionInterface */

--- a/tests/Query/QOM/QomToSql2ConverterTest.php
+++ b/tests/Query/QOM/QomToSql2ConverterTest.php
@@ -411,7 +411,7 @@ class QomToSql2ConverterTest extends BaseCase
 
         $result = $this->parser->convert($query);
         if (is_array($expectedSql2)) {
-            $this->assertTrue(in_array($result, $expectedSql2), "The statement '$result' does not match an expected variation");
+            $this->assertContains($result, $expectedSql2, "The statement '$result' does not match an expected variation");
         } else {
             $this->assertEquals($expectedSql2, $result);
         }

--- a/tests/Query/QOM/Sql2ToQomConverterTest.php
+++ b/tests/Query/QOM/Sql2ToQomConverterTest.php
@@ -55,7 +55,7 @@ class Sql2ToQomConverterTest extends \PHPCR\Test\BaseCase
         $this->assertEquals('nt:unstructured', $query->getSource()->getNodeTypeName());
 
         $cols = $query->getColumns();
-        $this->assertTrue(is_array($cols));
+        $this->assertInternalType('array', $cols);
         $this->assertCount(2, $cols);
 
         $this->assertEquals('u', $cols[0]->getselectorName());

--- a/tests/Query/QueryResultsTest.php
+++ b/tests/Query/QueryResultsTest.php
@@ -146,7 +146,7 @@ class QueryResultsTest extends QueryBaseCase
     {
         $seekName = '/tests_general_base/multiValueProperty';
 
-        $this->assertTrue(count($this->qr->getNodes()) > 0);
+        $this->assertGreaterThan(0, count($this->qr->getNodes()));
         foreach ($this->qr->getNodes() as $path => $node) {
             if ($seekName == $path) {
                 break;
@@ -202,7 +202,7 @@ class QueryResultsTest extends QueryBaseCase
         }
 
         $this->assertCount(1, $rows);
-        
+
         // returning a string value is, perhaps suprisingly, the correct behavior.
         $this->assertEquals('4 2 8', $rows[0]->getValue('data.longNumberToCompareMulti'));
     }

--- a/tests/Query/RowTest.php
+++ b/tests/Query/RowTest.php
@@ -87,7 +87,7 @@ class RowTest extends QueryBaseCase
 
     public function testGetPath()
     {
-        $this->assertTrue(in_array($this->row->getPath(), $this->resultPaths), 'not one of the expected results');
+        $this->assertContains($this->row->getPath(), $this->resultPaths, 'not one of the expected results');
     }
 
     public function testGetScore()

--- a/tests/Reading/BinaryReadMethodsTest.php
+++ b/tests/Reading/BinaryReadMethodsTest.php
@@ -55,18 +55,18 @@ hello world
     public function testReadBinaryValue()
     {
         $binary = $this->binaryProperty->getBinary();
-        $this->assertTrue(is_resource($binary));
+        $this->assertInternalType('resource', $binary);
         $this->assertEquals($this->decodedstring, stream_get_contents($binary));
 
         // stream must start when getting again
         $binary = $this->binaryProperty->getBinary();
-        $this->assertTrue(is_resource($binary));
+        $this->assertInternalType('resource', $binary);
         $this->assertEquals($this->decodedstring, stream_get_contents($binary), 'Stream must begin at start again on second read');
 
         // stream must not be the same
         fclose($binary);
         $binary = $this->binaryProperty->getBinary();
-        $this->assertTrue(is_resource($binary));
+        $this->assertInternalType('resource', $binary);
         $this->assertEquals($this->decodedstring, stream_get_contents($binary), 'Stream must be different for each call, fclose should not matter');
     }
 
@@ -100,7 +100,7 @@ hello world
         $vals = $binaryMulti->getValue();
         $this->assertInternalType('array', $vals);
         foreach ($vals as $value) {
-            $this->assertTrue(is_resource($value));
+            $this->assertInternalType('resource', $value);
             $this->assertEquals($this->decodedstring, stream_get_contents($value));
         }
     }
@@ -161,8 +161,8 @@ hello world
         $empty = $node->getProperty('empty_multidata');
         $this->assertEquals(PropertyType::BINARY, $empty->getType());
         $emptyValue = $empty->getBinary();
-        $this->assertTrue(is_array($emptyValue));
-        $this->assertTrue(count($emptyValue) === 0);
+        $this->assertInternalType('array', $emptyValue);
+        $this->assertCount(0, $emptyValue);
     }
 
     /**
@@ -174,8 +174,8 @@ hello world
         $single = $node->getProperty('single_multidata');
         $this->assertEquals(PropertyType::BINARY, $single->getType());
         $singleValue = $single->getBinary();
-        $this->assertTrue(is_array($singleValue));
-        $this->assertTrue(is_resource($singleValue[0]));
+        $this->assertInternalType('array', $singleValue);
+        $this->assertInternalType('resource', $singleValue[0]);
         $contents = stream_get_contents($singleValue[0]);
         $this->assertEquals($this->decodedstring, $contents);
     }

--- a/tests/Reading/NodeReadMethodsTest.php
+++ b/tests/Reading/NodeReadMethodsTest.php
@@ -496,7 +496,7 @@ class NodeReadMethodsTest extends BaseCase
     public function testGetIndex()
     {
         $index = $this->node->getIndex();
-        $this->assertTrue(is_numeric($index));
+        $this->assertInternalType('numeric', $index);
         $this->assertEquals(1, $index);
     }
 
@@ -523,7 +523,7 @@ class NodeReadMethodsTest extends BaseCase
         $this->assertCount(2, $iterator, 'Wrong number of references to idExample');
         foreach ($iterator as $prop) {
             $this->assertInstanceOf(PropertyInterface::class, $prop);
-            $this->assertTrue(in_array($prop, $source));
+            $this->assertContains($prop, $source);
         }
     }
 
@@ -594,7 +594,7 @@ class NodeReadMethodsTest extends BaseCase
         $this->assertCount(3, $iterator, 'Wrong number of weak references to weakreference_target');
         foreach ($iterator as $prop) {
             $this->assertInstanceOf(PropertyInterface::class, $prop);
-            $this->assertTrue(in_array($prop, $source, true));
+            $this->assertContains($prop, $source);
         }
     }
 

--- a/tests/Reading/PropertyReadMethodsTest.php
+++ b/tests/Reading/PropertyReadMethodsTest.php
@@ -207,7 +207,7 @@ class PropertyReadMethodsTest extends BaseCase
     public function testGetBinary()
     {
         $bin = $this->valProperty->getBinary();
-        $this->assertTrue(is_resource($bin));
+        $this->assertInternalType('resource', $bin);
         $str = $this->valProperty->getString();
         $this->assertEquals($str, stream_get_contents($bin));
         $this->assertEquals($this->valProperty->getLength(), strlen($str));
@@ -215,7 +215,7 @@ class PropertyReadMethodsTest extends BaseCase
         $prop = $this->node->getProperty('index.txt/jcr:content/jcr:data');
         $this->assertEquals(PropertyType::BINARY, $prop->getType(), 'Expected binary type');
         $bin = $prop->getValue();
-        $this->assertTrue(is_resource($bin));
+        $this->assertInternalType('resource', $bin);
         $this->assertNotNull(stream_get_contents($bin));
         fclose($bin);
     }
@@ -227,7 +227,7 @@ class PropertyReadMethodsTest extends BaseCase
         $arr = $prop->getValue();
         $this->assertInternalType('array', $arr);
         foreach ($arr as $bin) {
-            $this->assertTrue(is_resource($bin));
+            $this->assertInternalType('resource', $bin);
             $this->assertNotNull(stream_get_contents($bin));
         }
     }

--- a/tests/Reading/SessionReadMethodsTest.php
+++ b/tests/Reading/SessionReadMethodsTest.php
@@ -93,8 +93,8 @@ class SessionReadMethodsTest extends BaseCase
         ]);
 
         $this->assertCount(2, $nodes);
-        $this->assertTrue(isset($nodes['/tests_general_base']));
-        $this->assertTrue(isset($nodes['/tests_general_base/numberPropertyNode']));
+        $this->assertArrayHasKey('/tests_general_base', $nodes);
+        $this->assertArrayHasKey('/tests_general_base/numberPropertyNode', $nodes);
 
         foreach ($nodes as $key => $node) {
             $this->assertInstanceOf(NodeInterface::class, $node);
@@ -115,8 +115,8 @@ class SessionReadMethodsTest extends BaseCase
         ]));
 
         $this->assertCount(2, $nodes);
-        $this->assertTrue(isset($nodes['/tests_general_base']));
-        $this->assertTrue(isset($nodes['/tests_general_base/numberPropertyNode']));
+        $this->assertArrayHasKey('/tests_general_base', $nodes);
+        $this->assertArrayHasKey('/tests_general_base/numberPropertyNode', $nodes);
 
         foreach ($nodes as $key => $node) {
             $this->assertInstanceOf(NodeInterface::class, $node);
@@ -169,8 +169,8 @@ class SessionReadMethodsTest extends BaseCase
             '/tests_general_base/../not_existing/jcr:primaryType',
         ]);
         $this->assertCount(2, $properties);
-        $this->assertTrue(isset($properties['/tests_general_base/jcr:primaryType']));
-        $this->assertTrue(isset($properties['/tests_general_base/numberPropertyNode/jcr:primaryType']));
+        $this->assertArrayHasKey('/tests_general_base/jcr:primaryType', $properties);
+        $this->assertArrayHasKey('/tests_general_base/numberPropertyNode/jcr:primaryType', $properties);
         foreach ($properties as $key => $property) {
             $this->assertInstanceOf(PropertyInterface::class, $property);
             $this->assertEquals($key, $property->getPath());
@@ -186,8 +186,8 @@ class SessionReadMethodsTest extends BaseCase
             '/tests_general_base/../not_existing/jcr:primaryType',
         ]));
         $this->assertCount(2, $properties);
-        $this->assertTrue(isset($properties['/tests_general_base/jcr:primaryType']));
-        $this->assertTrue(isset($properties['/tests_general_base/numberPropertyNode/jcr:primaryType']));
+        $this->assertArrayHasKey('/tests_general_base/jcr:primaryType', $properties);
+        $this->assertArrayHasKey('/tests_general_base/numberPropertyNode/jcr:primaryType', $properties);
         foreach ($properties as $key => $property) {
             $this->assertInstanceOf(PropertyInterface::class, $property);
             $this->assertEquals($key, $property->getPath());

--- a/tests/Versioning/SimpleVersionTest.php
+++ b/tests/Versioning/SimpleVersionTest.php
@@ -60,7 +60,7 @@ class SimpleVersionTest extends BaseCase
     {
         $date = $this->simpleVersioned->getCreated();
         $diff = time() - $date->getTimestamp();
-        $this->assertTrue($diff < 60, 'creation date of the version we created in setupBeforeClass should be within the last few seconds');
+        $this->assertLessThan(60, $diff, 'creation date of the version we created in setupBeforeClass should be within the last few seconds');
     }
 
     public function testGetFrozenNode()

--- a/tests/Versioning/VersionHistoryTest.php
+++ b/tests/Versioning/VersionHistoryTest.php
@@ -402,15 +402,15 @@ class VersionHistoryTest extends BaseCase
         $version = $history->getVersion('1.0');
 
         $labels = $history->getVersionLabels($version);
-        $this->assertEquals(2, count($labels));
-        $this->assertTrue(in_array('stable', $labels));
-        $this->assertTrue(in_array('labelname', $labels));
+        $this->assertCount(2, $labels);
+        $this->assertContains('stable', $labels);
+        $this->assertContains('labelname', $labels);
 
         $labels = $history->getVersionLabels();
-        $this->assertEquals(3, count($labels));
-        $this->assertTrue(in_array('stable', $labels));
-        $this->assertTrue(in_array('labelname', $labels));
-        $this->assertTrue(in_array('anotherlabelname', $labels));
+        $this->assertCount(3, $labels);
+        $this->assertContains('stable', $labels);
+        $this->assertContains('labelname', $labels);
+        $this->assertContains('anotherlabelname', $labels);
     }
 
     /**

--- a/tests/Versioning/VersionTest.php
+++ b/tests/Versioning/VersionTest.php
@@ -76,7 +76,7 @@ class VersionTest extends BaseCase
     {
         $date = $this->version->getCreated();
         $diff = time() - $date->getTimestamp();
-        $this->assertTrue($diff < 60, 'creation date of the version we created in setupBeforeClass should be within the last few seconds');
+        $this->assertLessThan(60, $diff, 'creation date of the version we created in setupBeforeClass should be within the last few seconds');
     }
 
     public function testGetFrozenNode()

--- a/tests/Writing/CopyMethodsTest.php
+++ b/tests/Writing/CopyMethodsTest.php
@@ -275,8 +275,8 @@ class CopyMethodsTest extends BaseCase
         $srcVal = $srcProp->getBinary();
         $dstVal = $dstProp->getBinary();
 
-        $this->assertTrue(is_resource($srcVal), 'Failed to get src binary stream');
-        $this->assertTrue(is_resource($dstVal), 'Failed to get dst binary stream');
+        $this->assertInternalType('resource', $srcVal, 'Failed to get src binary stream');
+        $this->assertInternalType('resource', $dstVal, 'Failed to get dst binary stream');
 
         $this->assertEquals(stream_get_contents($srcVal), stream_get_contents($dstVal));
     }
@@ -303,13 +303,13 @@ class CopyMethodsTest extends BaseCase
         $srcVal = $srcProp->getValue();
         $dstVal = $dstProp->getValue();
 
-        $this->assertTrue(is_array($srcVal), 'Failed to get src value');
-        $this->assertTrue(is_array($dstVal), 'Failed to get dst value');
+        $this->assertInternalType('array', $srcVal, 'Failed to get src value');
+        $this->assertInternalType('array', $dstVal, 'Failed to get dst value');
 
-        $this->assertTrue(is_resource($srcVal[0]));
-        $this->assertTrue(is_resource($srcVal[1]));
-        $this->assertTrue(is_resource($dstVal[0]));
-        $this->assertTrue(is_resource($dstVal[1]));
+        $this->assertInternalType('resource', $srcVal[0]);
+        $this->assertInternalType('resource', $srcVal[1]);
+        $this->assertInternalType('resource', $dstVal[0]);
+        $this->assertInternalType('resource', $dstVal[1]);
 
         $this->assertEquals(stream_get_contents($srcVal[0]), stream_get_contents($dstVal[0]));
         $this->assertEquals(stream_get_contents($srcVal[1]), stream_get_contents($dstVal[1]));

--- a/tests/Writing/MixinCreatedTest.php
+++ b/tests/Writing/MixinCreatedTest.php
@@ -48,7 +48,7 @@ class MixinCreatedTest extends BaseCase
         $this->assertInstanceOf(DateTime::class, $date);
         /* @var $date DateTime */
         $diff = time() - $date->getTimestamp();
-        $this->assertTrue($diff < 60 * 10, 'jcr:created should be current date as fixture was just imported: '.$date->format('c'));
+        $this->assertLessThan(60 * 10, $diff, 'jcr:created should be current date as fixture was just imported: '.$date->format('c'));
 
         // Re-read the node to be sure things got properly saved
         $this->renewSession();
@@ -59,6 +59,6 @@ class MixinCreatedTest extends BaseCase
         $date = $child->getPropertyValue('jcr:created');
         $this->assertInstanceOf(DateTime::class, $date);
         $diff = time() - $date->getTimestamp();
-        $this->assertTrue($diff < 60 * 10, 'jcr:created should be current date as fixture was just imported: '.$date->format('c'));
+        $this->assertLessThan(60 * 10, $diff, 'jcr:created should be current date as fixture was just imported: '.$date->format('c'));
     }
 }

--- a/tests/Writing/NamespaceRegistryTest.php
+++ b/tests/Writing/NamespaceRegistryTest.php
@@ -43,14 +43,14 @@ class NamespaceRegistryTest extends BaseCase
     {
         $ret = $this->nr->getPrefixes();
         $this->assertInternalType('array', $ret);
-        $this->assertTrue(count($ret) >= count($this->nsBuiltIn));
+        $this->assertGreaterThanOrEqual(count($this->nsBuiltIn), count($ret));
     }
 
     public function testGetURIs()
     {
         $ret = $this->nr->getURIs();
         $this->assertInternalType('array', $ret);
-        $this->assertTrue(count($ret) >= count($this->nsBuiltIn));
+        $this->assertGreaterThanOrEqual(count($this->nsBuiltIn), count($ret));
         //we test in getURI / getPrefix if the names match
     }
 
@@ -150,6 +150,6 @@ class NamespaceRegistryTest extends BaseCase
             $this->assertInternalType('string', $url);
             $this->assertEquals($url, $this->nr->getURI($prefix));
         }
-        $this->assertTrue($results > 3, 'Not enough namespaces');
+        $this->assertGreaterThan(3, $results, 'Not enough namespaces');
     }
 }

--- a/tests/Writing/SetPropertyDynamicRebindingTest.php
+++ b/tests/Writing/SetPropertyDynamicRebindingTest.php
@@ -77,7 +77,7 @@ class SetPropertyDynamicRebindingTest extends BaseCase
             $this->assertEquals($sourcePropValue, $prop->getValue(), 'Initial property value does not match before saving');
         } else {
             // PHPUnit does not like to assertEquals on resources
-            $this->assertTrue(is_resource($prop->getValue()));
+            $this->assertInternalType('resource', $prop->getValue());
         }
 
         // Read it from backend check it's still valid
@@ -97,7 +97,7 @@ class SetPropertyDynamicRebindingTest extends BaseCase
             $this->assertEquals($sourcePropValue, $prop->getValue(), 'Initial property value does not match after saving');
         } else {
             // PHPUnit does not like to assertEquals on resources
-            $this->assertTrue(is_resource($prop->getValue()));
+            $this->assertInternalType('resource', $prop->getValue());
         }
 
         try {

--- a/tests/Writing/SetPropertyTypesTest.php
+++ b/tests/Writing/SetPropertyTypesTest.php
@@ -82,7 +82,7 @@ class SetPropertyTypesTest extends BaseCase
         $oldSession = $this->session;
         $this->saveAndRenewSession(); // either this
         $oldSession->logout(); // or this should close the stream
-        $this->assertFalse(is_resource($stream), 'The responsibility for the stream goes into phpcr who must close it');
+        $this->assertNotInternalType('resource', $stream, 'The responsibility for the stream goes into phpcr who must close it');
 
         $bin = $this->session->getProperty('/tests_general_base/numberPropertyNode/jcr:content/newBinaryStream');
         $this->assertEquals(PropertyType::BINARY, $bin->getType());
@@ -102,7 +102,7 @@ class SetPropertyTypesTest extends BaseCase
         $oldSession = $this->session;
         $this->saveAndRenewSession(); // either this
         $oldSession->logout(); // or this should close the stream
-        $this->assertFalse(is_resource($stream), 'The responsibility for the stream goes into phpcr who must close it');
+        $this->assertNotInternalType('resource', $stream, 'The responsibility for the stream goes into phpcr who must close it');
 
         $bin = $this->session->getProperty('/tests_general_base/numberPropertyNode/jcr:content/newBinaryStream');
         $this->assertEquals(PropertyType::BINARY, $bin->getType());
@@ -185,13 +185,13 @@ class SetPropertyTypesTest extends BaseCase
         $this->assertInstanceOf(PropertyInterface::class, $value);
         $this->assertEquals(PropertyType::BOOLEAN, $value->getType(), 'wrong type');
         $this->assertTrue($value->getBoolean(), 'boolean not true');
-        $this->assertTrue($value->getString() == true, 'wrong string value'); //boolean converted to string must be true
+        $this->assertEquals(true, $value->getString(), 'wrong string value'); //boolean converted to string must be true
 
         $this->saveAndRenewSession();
         $value = $this->session->getProperty('/tests_general_base/numberPropertyNode/jcr:content/propBoolean');
         $this->assertEquals(PropertyType::BOOLEAN, $value->getType(), 'wrong type');
         $this->assertTrue($value->getBoolean(), 'boolean not true');
-        $this->assertTrue($value->getString() == true, 'wrong string value'); //boolean converted to string must be true
+        $this->assertEquals(true, $value->getString(), 'wrong string value'); //boolean converted to string must be true
     }
 
     public function testCreateValueNode()


### PR DESCRIPTION
I've refactored some tests, using:
- `assertCount` instead of `count` function;
- `assertSame` instead of strict comparisons `===`;
- `assertArrayHasKey` instead of `isset` function;
- `assertContains` instead of `in_array` function;
- `assertInternalType` and `assertNotInternalType` instead of `is_*` functions;
- `assertGreaterThan` and `assertGreaterThanOrEqual` for mathematical comparisons;
- `assertEquals` instead of comparisons `==`.