### PR TITLE
Fix expected exception in RepositoryTest

### DIFF
--- a/tests/Connecting/RepositoryTest.php
+++ b/tests/Connecting/RepositoryTest.php
@@ -56,7 +56,7 @@ class RepositoryTest extends BaseCase
     {
         $repository = self::$loader->getRepository();
         if (!self::$loader->prepareAnonymousLogin()) {
-            $this->setExpectedException(LoginException::class);
+            $this->expectException(LoginException::class);
         }
 
         $session = $repository->login(null, self::$loader->getWorkspaceName());
@@ -72,7 +72,7 @@ class RepositoryTest extends BaseCase
     {
         $repository = self::$loader->getRepository();
         if (!self::$loader->prepareAnonymousLogin()) {
-            $this->setExpectedException(LoginException::class);
+            $this->expectException(LoginException::class);
         }
 
         $session = $repository->login();


### PR DESCRIPTION
When using PhpUnit 7 setExpectedException is not available since phpunit 5.2 it should be expectException.